### PR TITLE
Add data query metadata schemas

### DIFF
--- a/candidate-standard/openapi/schemas/collection.json
+++ b/candidate-standard/openapi/schemas/collection.json
@@ -2,7 +2,8 @@
     "type": "object",
     "required": [
       "links",
-      "id"
+      "id",
+      "dataQueries"
     ],
     "properties": {
       "links": {
@@ -100,17 +101,12 @@
           "miles"
         ]
       },
-      "outputformat": {
-        "description": "list of formats the results can be presented in",
+      "dataQueries": {
         "type": "array",
-        "items": "string",
-        "example": [
-          "CoverageJSON",
-          "GeoJSON",
-          "IWXXM",
-          "GRIB"
-        ]
-      },
+        "items": {
+          "$ref": "dataQuery.json"
+        }
+      },      
       "parameters": {
         "description": "list of the data parameters available in the collection",
         "type": "object",

--- a/candidate-standard/openapi/schemas/collection.yaml
+++ b/candidate-standard/openapi/schemas/collection.yaml
@@ -2,6 +2,7 @@ type: object
 required:
   - links
   - id
+  - dataQueries
 properties:
   links:
     type: array
@@ -74,15 +75,10 @@ properties:
     example:
       - km
       - miles
-  outputformat:
-    description: list of formats the results can be presented in
+  dataQueries:
     type: array
-    items: string
-    example:
-      - CoverageJSON
-      - GeoJSON
-      - IWXXM
-      - GRIB
+    items:
+      $ref: dataQuery.yaml      
   parameters:
     description: list of the data parameters available in the collection
     type: object

--- a/candidate-standard/openapi/schemas/dataQuery.json
+++ b/candidate-standard/openapi/schemas/dataQuery.json
@@ -1,0 +1,65 @@
+{
+    "type": "object",
+    "properties": {
+        "id": {
+            "type": "string"
+        },
+        "title": {
+            "type": "string"
+        },
+        "description": {
+            "type": "string"
+        },
+        "links": {
+            "type": "array",
+            "items": {
+                "$ref": "link.json"
+            }
+        },
+        "outputFormats": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "example": [
+                "CoverageJSON",
+                "KML",
+                "GeoJSON",
+                "GRIB2",
+                "NetCDF3",
+                "NetCDF4"
+            ]
+        },
+        "defaultOutputFormat": {
+            "type": "string",
+            "example": "CoverageJSON"
+        }
+    },
+    "required": [
+        "id",
+        "links",
+        "outputFormats",
+        "defaultOutputFormat"
+    ],
+    "example": {
+        "id": "position",
+        "title": "Position Query",
+        "description": "Data at point location",
+        "links": [
+            {
+                "href": "https://www.example.com/edr/collections/srtm/position",
+                "rel": "data",
+                "title": "Position Query"
+            }
+        ],
+        "outputFormats": [
+            "CoverageJSON",
+            "KML",
+            "GeoJSON",
+            "GRIB2",
+            "NetCDF3",
+            "NetCDF4"
+        ],
+        "defaultOutputFormat": "CoverageJSON"
+    }
+}

--- a/candidate-standard/openapi/schemas/dataQuery.yaml
+++ b/candidate-standard/openapi/schemas/dataQuery.yaml
@@ -1,0 +1,47 @@
+type: object
+properties:
+  id:
+    type: string
+  title:
+    type: string
+  description:
+    type: string
+  links:
+    type: array
+    items:
+      $ref: link.json
+  outputFormats:
+    type: array
+    items:
+      type: string
+    example:
+      - CoverageJSON
+      - KML
+      - GeoJSON
+      - GRIB2
+      - NetCDF3
+      - NetCDF4
+  defaultOutputFormat:
+    type: string
+    example: CoverageJSON
+required:
+  - id
+  - links
+  - outputFormats
+  - defaultOutputFormat
+example:
+  id: position
+  title: Position Query
+  description: Data at point location
+  links:
+    - href: https://www.example.com/edr/collections/srtm/position
+      rel: data
+      title: Position Query
+  outputFormats:
+    - CoverageJSON
+    - KML
+    - GeoJSON
+    - GRIB2
+    - NetCDF3
+    - NetCDF4
+  defaultOutputFormat: CoverageJSON


### PR DESCRIPTION
This implements the changes to the collections metadata proposed in #166 

- Adds a new `dataQueries` object to allow support for different output formats for each supported query pattern.
- Removes the collection level `outputFormat` attribute