### PR TITLE
Use iso position definition

### DIFF
--- a/candidate-standard/clause_4_terms_and_definitions.adoc
+++ b/candidate-standard/clause_4_terms_and_definitions.adoc
@@ -46,7 +46,7 @@ SOURCE: https://www.iso.org/standard/32551.html[ISO 19133:2005]:
 [[radius-definition]]
 === radius
 
-region specified with a geographic point and radial distance
+region specified with a geographic position and radial distance
 
 [[trajectory-definition]]
 === trajectory

--- a/candidate-standard/clause_4_terms_and_definitions.adoc
+++ b/candidate-standard/clause_4_terms_and_definitions.adoc
@@ -39,7 +39,9 @@ version, release, or run of a given data collection
 [[position-definition]]
 === position
 
-a place specified with a geographic point
+data type that describes a point or geometry potentially occupied by an object or person
+
+SOURCE: https://www.iso.org/standard/32551.html[ISO 19133:2005]:
 
 [[radius-definition]]
 === radius

--- a/candidate-standard/clause_8_queries.adoc
+++ b/candidate-standard/clause_8_queries.adoc
@@ -53,7 +53,7 @@ The OGC API-Common standards do not define any information resource types. Howev
 [width="90%",cols="2,1,4",options="header"]
 |===
 ^|**Path Template** ^|**Query Type** ^|**Description**
-|/collections/{collectionId}/position | Position | Return data for the requested <<position-definition,point location>>
+|/collections/{collectionId}/position | Position | Return data for the requested <<position-definition,position location>>
 |/collections/{collectionId}/radius | Radius | Return data within a given <<radius-definition,radius>> of a position
 |/collections/{collectionId}/area | Area | Return data for the requested <<area-definition,area>>
 |/collections/{collectionId}/cube | Cube | Return data for a spatial <<cube-definition,cube>>

--- a/candidate-standard/requirements/edr/query_type/instance.adoc
+++ b/candidate-standard/requirements/edr/query_type/instance.adoc
@@ -31,10 +31,10 @@ The queryType options are exactly the same as those available to <<collection-de
 see the <<query-resources-section>> section for details of the query parameters supported by the queryTypes.
 
 
-. A point query on an Raw data instance(instanceId = raw) for the Metar ((collectionId = metar) <<collection-definition,collection>> 
+. A posiotion query on an Raw data instance(instanceId = raw) for the Metar ((collectionId = metar) <<collection-definition,collection>> 
 =================
 
-/collections/metar/instance/raw/point
+/collections/metar/instance/raw/position
 
 
 =================

--- a/candidate-standard/requirements/edr/query_type/instance.adoc
+++ b/candidate-standard/requirements/edr/query_type/instance.adoc
@@ -31,7 +31,7 @@ The queryType options are exactly the same as those available to <<collection-de
 see the <<query-resources-section>> section for details of the query parameters supported by the queryTypes.
 
 
-. A posiotion query on an Raw data instance(instanceId = raw) for the Metar ((collectionId = metar) <<collection-definition,collection>> 
+. A position query on an Raw data instance(instanceId = raw) for the Metar ((collectionId = metar) <<collection-definition,collection>> 
 =================
 
 /collections/metar/instance/raw/position

--- a/candidate-standard/requirements/edr/query_type/locations.adoc
+++ b/candidate-standard/requirements/edr/query_type/locations.adoc
@@ -1,6 +1,6 @@
 ===== Parameter locationID
 
-With the locations query a location is defined by a unique identifier, this is a string value.  It can be anything as long as it is unique for the required location, for instance a GeoHash `gbsvn` or a WMO station id like `03772`, what3words like `bolt.lime.metro` or place name like `Devon`.  The metadata returned by the API must supply a geospatial definition for the identifier.
+With the locations query a position is defined by a unique identifier, this is a string value.  It can be anything as long as it is unique for the required position, for instance a GeoHash `gbsvn` or a WMO station id like `03772`, what3words like `bolt.lime.metro` or place name like `Devon`.  The metadata returned by the API must supply a geospatial definition for the identifier.
 
 
 .get list of location id's

--- a/candidate-standard/requirements/edr/query_type/locations.adoc
+++ b/candidate-standard/requirements/edr/query_type/locations.adoc
@@ -1,6 +1,6 @@
 ===== Parameter locationID
 
-With the locations query a position is defined by a unique identifier, this is a string value.  It can be anything as long as it is unique for the required position, for instance a GeoHash `gbsvn` or a WMO station id like `03772`, what3words like `bolt.lime.metro` or place name like `Devon`.  The metadata returned by the API must supply a geospatial definition for the identifier.
+With the locations query a position is defined by a unique identifier that is a string value.  It can be anything as long as it is unique for the required position, for instance a GeoHash `gbsvn` or a WMO station id like `03772`, what3words like `bolt.lime.metro` or place name like `Devon`.  The metadata returned by the API must supply a geospatial definition for the identifier.
 
 
 .get list of location id's

--- a/candidate-standard/requirements/edr/query_type/radius.adoc
+++ b/candidate-standard/requirements/edr/query_type/radius.adoc
@@ -7,29 +7,29 @@ The Radius query returns data within the defined radius of the requested coordin
 <<req_edr_coords-response>>
 
 position(s) to return data for, the coordinates are defined by a Well Known Text
-(wkt) string. To retrieve data for a single location :
+(wkt) string. To retrieve data for a single location:
 
 POINT(x y) 
 
-A position at height `z`
+A position at height `z`:
+
 POINT(x y z)
 
-And for a list of positions
+And for a list of positions:
 
 MULTIPOINT\((x y),(x1 y1),(x2 y2),(x3 y3))
 
-And for a list of positions at defined heights
+And for a list of positions at defined heights:
 
 MULTIPOINT\((x y z),(x1 y1 z1),(x2 y2 z2),(x3 y3 z3))
 
-see http://portal.opengeospatial.org/files/?artifact_id=25355 and https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry
+See http://portal.opengeospatial.org/files/?artifact_id=25355 and https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry
 
-The coordinate values will depend on the CRS parameter. If this is not defined
-the values will be assumed to be WGS84 values (i.e x=longitude and y=latitude)
+The coordinate values will depend on the CRS parameter. If this is not defined, the values will be assumed to be WGS84 values (i.e x=longitude and y=latitude)
 
 .Single location
 =================
-retrieve data for Greenwich, London
+Retrieve data for Greenwich, London
 
 `coords=POINT(0 51.48)`
 =================
@@ -51,7 +51,7 @@ The units supported by the collection will be listed in the collections end poin
 
 .Define a 20Km radius
 ===========
-i.e. Define a Radius of 20 Km from the position defined by the coords query parameter  
+I.e. Define a Radius of 20 Km from the position defined by the coords query parameter  
 
 `within=20&within-units=km`
 
@@ -69,9 +69,11 @@ i.e. Define a Radius of 5 miles from the location defined by the coords query pa
 ===== *Parameter z*
 
 Define the vertical level to return data from 
+
 i.e. z=level
 
 if data at all available levels is required z can be defined as ALL
+
 i.e. z=ALL
 
 .A single vertical level
@@ -88,8 +90,7 @@ For example if the 80m level is being queried
 `z=ALL`
 ===========
 
-When not specified the API MUST return data from all available levels.
-
+When z is not specified, the API MUST return data from all available levels.
 
 ===== <<time>>
 

--- a/candidate-standard/requirements/edr/query_type/radius.adoc
+++ b/candidate-standard/requirements/edr/query_type/radius.adoc
@@ -7,7 +7,9 @@ The Radius query returns data within the defined radius of the requested coordin
 <<req_edr_coords-response>>
 
 position(s) to return data for, the coordinates are defined by a Well Known Text
-(wkt) string. To retrieve data for a single location:
+(wkt) string. 
+
+To retrieve data for a single location:
 
 POINT(x y) 
 

--- a/candidate-standard/requirements/edr/query_type/radius.adoc
+++ b/candidate-standard/requirements/edr/query_type/radius.adoc
@@ -70,18 +70,14 @@ i.e. Define a Radius of 5 miles from the location defined by the coords query pa
 
 ===== *Parameter z*
 
-Define the vertical level to return data from 
+Define the vertical level to return data from, i.e. z=level
 
-i.e. z=level
-
-if data at all available levels is required z can be defined as ALL
-
-i.e. z=ALL
+if data at all available levels is required z can be defined as ALL, i.e. z=ALL
 
 .A single vertical level
 ===========
 
-For example if the 80m level is being queried
+For example if the 80m level is being queried:
 
 `z=80`
 ===========

--- a/candidate-standard/requirements/edr/query_type/radius.adoc
+++ b/candidate-standard/requirements/edr/query_type/radius.adoc
@@ -6,19 +6,19 @@ The Radius query returns data within the defined radius of the requested coordin
 
 <<req_edr_coords-response>>
 
-location(s) to return data for, the coordinates are defined by a Well Known Text
+position(s) to return data for, the coordinates are defined by a Well Known Text
 (wkt) string. To retrieve data for a single location :
 
 POINT(x y) 
 
-A point at height `z`
+A position at height `z`
 POINT(x y z)
 
-And for a list of locations
+And for a list of positions
 
 MULTIPOINT\((x y),(x1 y1),(x2 y2),(x3 y3))
 
-And for a list of locations at defined heights
+And for a list of positions at defined heights
 
 MULTIPOINT\((x y z),(x1 y1 z1),(x2 y2 z2),(x3 y3 z3))
 
@@ -51,7 +51,7 @@ The units supported by the collection will be listed in the collections end poin
 
 .Define a 20Km radius
 ===========
-i.e. Define the a Radius of 20 Km from the location defined by the coords query parameter  
+i.e. Define a Radius of 20 Km from the position defined by the coords query parameter  
 
 `within=20&within-units=km`
 
@@ -59,7 +59,7 @@ i.e. Define the a Radius of 20 Km from the location defined by the coords query 
 
 .Define a 5 mile radius
 ===========
-i.e. Define the a Radius of 5 miles from the location defined by the coords query parameter  
+i.e. Define a Radius of 5 miles from the location defined by the coords query parameter  
 
 `within=5&within-units=miles`
 


### PR DESCRIPTION
Replaced Position definition with ISO one, and changed some "location" and "point" occurences to "position".
Also cross-checked the various ISO definitions.

This addresses  Issue TC E-vote Comment 5e: Definition of Position #198