### PR TITLE
add optional query metadata

### DIFF
--- a/candidate-standard/examples/collections_metadata_JSON_1.adoc
+++ b/candidate-standard/examples/collections_metadata_JSON_1.adoc
@@ -119,23 +119,67 @@ There are also links to the license information for the observation and forecast
                 }
             },
             "crs": [
-                {
-                    "name": "CRS84",
-                    "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
-                }
+                "EPSG:4326"
             ],
-            "distanceunits": [
-                "km",
-                "miles"
-            ],
-            "outputformat": [
-                {
-                    "name": "GeoJSON",
-                    "data_schema": "http://www.example.org/edr/static/json/dp_schema.json"
+            "dataQueries": {
+                "position": {
+                    "title": "Position query",
+                    "description": "Position query",
+                    "outputformat": [
+                        "CoverageJSON",
+                        "GeoJSON",
+                        "IWXXM"
+                    ],
+                    "defaultOutputFormat": "IWXXM",
+                    "crs": [
+                        {
+                            "name": "CRS84",
+                            "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
+                        }
+                    ]
                 },
-                {
-                    "name": "CoverageJSON"
+                "radius": {
+                    "title": "Radius query",
+                    "description": "Radius query",
+                    "outputformat": [
+                        "CoverageJSON",
+                        "GeoJSON",
+                        "IWXXM"
+                    ],
+                    "defaultOutputFormat": "GeoJSON",
+                    "width-units": [
+                        "km",
+                        "miles"
+                    ]
+                    "crs": [
+                        {
+                            "name": "CRS84",
+                            "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
+                        }
+                    ]
+                },
+                "area": {
+                    "title": "Area query",
+                    "description": "Area query",
+                    "outputformat": [
+                        "CoverageJSON",
+                        "GeoJSON",
+                        "BUFR",
+                        "IWXXM"
+                    ],
+                    "defaultOutputFormat": "CoverageJSON",
+                    "crs": [
+                        {
+                            "name": "CRS84",
+                            "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
+                        }
+                    ]
                 }
+            },
+            "outputformat": [
+                "CoverageJSON",
+                "GeoJSON",
+                "IWXXM"
             ],
             "parameters": {
                 "Wind Direction": {
@@ -454,23 +498,62 @@ There are also links to the license information for the observation and forecast
                 }
             },
             "crs": [
-                {
-                    "name": "CRS84",
-                    "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
-                }
+                "EPSG:4326"
             ],
-            "distanceunits": [
-                "km",
-                "miles"
-            ],
-            "outputformat": [
-                {
-                    "name": "GeoJSON",
-                    "data_schema": "http://www.example.org/edr/static/json/dp_schema.json"
+            "dataQueries": {
+                "position": {
+                    "title": "Position query",
+                    "description": "Position query",
+                    "outputformat": [
+                        "CoverageJSON",
+                        "GeoJSON"
+                    ],
+                    "defaultOutputFormat": "GeoJSON",
+                    "crs": [
+                        {
+                            "name": "CRS84",
+                            "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
+                        }
+                    ]
                 },
-                {
-                    "name": "CoverageJSON"
+                "radius": {
+                    "title": "Radius query",
+                    "description": "Radius query",
+                    "outputformat": [
+                        "CoverageJSON",
+                        "GeoJSON"
+                    ],
+                    "defaultOutputFormat": "GeoJSON",
+                    "width-units": [
+                        "km",
+                        "miles"
+                    ]
+                    "crs": [
+                        {
+                            "name": "CRS84",
+                            "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
+                        }
+                    ]
+                },
+                "area": {
+                    "title": "Area query",
+                    "description": "Area query",
+                    "outputformat": [
+                        "CoverageJSON",
+                        "GeoJSON"
+                    ],
+                    "defaultOutputFormat": "CoverageJSON",
+                    "crs": [
+                        {
+                            "name": "CRS84",
+                            "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
+                        }
+                    ]
                 }
+            },
+            "outputformat": [
+                "CoverageJSON",
+                "GeoJSON"
             ],
             "parameters": {
                 "Wind Direction": {
@@ -724,8 +807,8 @@ There are also links to the license information for the observation and forecast
                     }
                 }
             }
-        }        
+        }
     ]
-}     
+}    
 ----
 =================

--- a/candidate-standard/examples/collections_metadata_JSON_1.adoc
+++ b/candidate-standard/examples/collections_metadata_JSON_1.adoc
@@ -77,21 +77,74 @@ There are also links to the license information for the observation and forecast
                     "hreflang": "en",
                     "rel": "data",
                     "type": "position",
-                    "title": ""
+                    "title": "",
+                    "variables": {
+                        "title": "Position query",
+                        "description": "Position query",
+                        "output_formats": [
+                            "CoverageJSON",
+                            "GeoJSON",
+                            "IWXXM"
+                        ],
+                        "default_output_format": "IWXXM",
+                        "crs_details": [
+                            {
+                                "crs": "CRS84",
+                                "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
+                            }
+                        ]    
+                    }
                 },
                 {
                     "href": "http://www.example.org/edr/collections/hrly_obs/radius",
                     "hreflang": "en",
                     "rel": "data",
                     "type": "radius",
-                    "title": ""
+                    "title": "",
+                    "variables": {
+                        "title": "Radius query",
+                        "description": "Radius query",
+                        "output_formats": [
+                            "CoverageJSON",
+                            "GeoJSON",
+                            "IWXXM"
+                        ],
+                        "default_output_format": "GeoJSON",
+                        "width_units": [
+                            "km",
+                            "miles"
+                        ],
+                        "crs_details": [
+                            {
+                                "crs": "CRS84",
+                                "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
+                            }
+                        ]    
+                    }
                 },
                 {
                     "href": "http://www.example.org/edr/collections/hrly_obs/area",
                     "hreflang": "en",
                     "rel": "data",
                     "type": "area",
-                    "title": ""
+                    "title": "",
+                    "variables": {
+                        "title": "Area query",
+                        "description": "Area query",
+                        "output_formats": [
+                            "CoverageJSON",
+                            "GeoJSON",
+                            "BUFR",
+                            "IWXXM"
+                        ],
+                        "default_output_format": "CoverageJSON",
+                        "crs_details": [
+                            {
+                                "crs": "CRS84",
+                                "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
+                            }
+                        ]    
+                    }
                 },
                 {
                     "href": "http://www.example.org/edr/collections/hrly_obs/locations",
@@ -121,67 +174,12 @@ There are also links to the license information for the observation and forecast
             "crs": [
                 "CRS84"
             ],
-            "data-queries": {
-                "position": {
-                    "title": "Position query",
-                    "description": "Position query",
-                    "output-formats": [
-                        "CoverageJSON",
-                        "GeoJSON",
-                        "IWXXM"
-                    ],
-                    "default-output-format": "IWXXM",
-                    "crs-details": [
-                        {
-                            "crs": "CRS84",
-                            "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
-                        }
-                    ]
-                },
-                "radius": {
-                    "title": "Radius query",
-                    "description": "Radius query",
-                    "output-formats": [
-                        "CoverageJSON",
-                        "GeoJSON",
-                        "IWXXM"
-                    ],
-                    "default-output-format": "GeoJSON",
-                    "width-units": [
-                        "km",
-                        "miles"
-                    ],
-                    "crs-details": [
-                        {
-                            "crs": "CRS84",
-                            "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
-                        }
-                    ]
-                },
-                "area": {
-                    "title": "Area query",
-                    "description": "Area query",
-                    "output-formats": [
-                        "CoverageJSON",
-                        "GeoJSON",
-                        "BUFR",
-                        "IWXXM"
-                    ],
-                    "default-output-format": "CoverageJSON",
-                    "crs-details": [
-                        {
-                            "crs": "CRS84",
-                            "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
-                        }
-                    ]
-                }
-            },
-            "output-formats": [
+            "output_formats": [
                 "CoverageJSON",
                 "GeoJSON",
                 "IWXXM"
             ],
-            "parameters": {
+            "parameter_names": {
                 "Wind Direction": {
                     "type": "Parameter",
                     "description": "",
@@ -439,63 +437,12 @@ There are also links to the license information for the observation and forecast
             },
             "crs": [
                 "CRS84"
-            ],
-            "data-queries": {
-                "position": {
-                    "title": "Position query",
-                    "description": "Position query",
-                    "output-formats": [
-                        "CoverageJSON",
-                        "GeoJSON"
-                    ],
-                    "default-output-format": "GeoJSON",
-                    "crs-details": [
-                        {
-                            "crs": "CRS84",
-                            "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
-                        }
-                    ]
-                },
-                "radius": {
-                    "title": "Radius query",
-                    "description": "Radius query",
-                    "output-formats": [
-                        "CoverageJSON",
-                        "GeoJSON"
-                    ],
-                    "default-output-format": "GeoJSON",
-                    "width-units": [
-                        "km",
-                        "miles"
-                    ],
-                    "crs-details": [
-                        {
-                            "crs": "CRS84",
-                            "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
-                        }
-                    ]
-                },
-                "area": {
-                    "title": "Area query",
-                    "description": "Area query",
-                    "output-formats": [
-                        "CoverageJSON",
-                        "GeoJSON"
-                    ],
-                    "default-output-format": "CoverageJSON",
-                    "crs-details": [
-                        {
-                            "crs": "CRS84",
-                            "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
-                        }
-                    ]
-                }
-            },
-            "output-formats": [
+           ],
+            "output_formats": [
                 "CoverageJSON",
                 "GeoJSON"
             ],
-            "parameter-names": {
+            "parameter_names": {
                 "Wind Direction": {
                     "type": "Parameter",
                     "description": "Direction wind is from",

--- a/candidate-standard/examples/collections_metadata_JSON_1.adoc
+++ b/candidate-standard/examples/collections_metadata_JSON_1.adoc
@@ -73,7 +73,7 @@ There are also links to the license information for the observation and forecast
                     "title": ""
                 },
                 {
-                    "href": "http://www.example.org/edr/collections/hrly_obs/position",
+                    "href": "http://www.example.org/edr/collections/hrly_obs/position?coords={coords}",
                     "hreflang": "en",
                     "rel": "data",
                     "title": "",
@@ -81,6 +81,10 @@ There are also links to the license information for the observation and forecast
                         "title": "Position query",
                         "description": "Position query",
                         "query_type": "position",
+                        "templated": true,
+                        "coords" :{
+                            "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
+                        },
                         "output_formats": [
                             "CoverageJSON",
                             "GeoJSON",
@@ -96,7 +100,7 @@ There are also links to the license information for the observation and forecast
                     }
                 },
                 {
-                    "href": "http://www.example.org/edr/collections/hrly_obs/radius",
+                    "href": "http://www.example.org/edr/collections/hrly_obs/radius?coords={coords}",
                     "hreflang": "en",
                     "rel": "data",
                     "title": "",
@@ -104,6 +108,10 @@ There are also links to the license information for the observation and forecast
                         "title": "Radius query",
                         "description": "Radius query",
                         "query_type": "radius",
+                        "templated": true,
+                        "coords" :{
+                            "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
+                        },
                         "output_formats": [
                             "CoverageJSON",
                             "GeoJSON",
@@ -123,7 +131,7 @@ There are also links to the license information for the observation and forecast
                     }
                 },
                 {
-                    "href": "http://www.example.org/edr/collections/hrly_obs/area",
+                    "href": "http://www.example.org/edr/collections/hrly_obs/area?coords={coords}",
                     "hreflang": "en",
                     "rel": "data",
                     "title": "",
@@ -131,6 +139,10 @@ There are also links to the license information for the observation and forecast
                         "title": "Area query",
                         "description": "Area query",
                         "query_type": "area",
+                        "templated": true,
+                        "coords" :{
+                            "description": "Well Known Text POLYGON value i.e. POLYGON((-79 40,-79 38,-75 38,-75 41,-79 40))"
+                        },
                         "output_formats": [
                             "CoverageJSON",
                             "GeoJSON",
@@ -150,7 +162,25 @@ There are also links to the license information for the observation and forecast
                     "href": "http://www.example.org/edr/collections/hrly_obs/locations",
                     "hreflang": "en",
                     "rel": "data",
-                    "title": ""
+                    "variables": {
+                        "title": "Location query",
+                        "description": "Location query",
+                        "query_type": "location",
+                        "templated": false,
+                        "output_formats": [
+                            "CoverageJSON",
+                            "GeoJSON",
+                            "BUFR",
+                            "IWXXM"
+                        ],
+                        "default_output_format": "CoverageJSON",
+                        "crs_details": [
+                            {
+                                "crs": "CRS84",
+                                "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
+                            }
+                        ]    
+                    }
                 }
             ],
             "extent": {
@@ -392,28 +422,24 @@ There are also links to the license information for the observation and forecast
                     "href": "https://http://www.example.org/uk-3-hourly-site-specific-forecast",
                     "hreflang": "en",
                     "rel": "service-doc",
-                    "type": "text/html",
-                    "title": ""
+                    "type": "text/html"
                 },
                 {
                     "href": "https://http://www.example.org/terms-and-conditions---datapoint#datalicence",
                     "hreflang": "en",
                     "rel": "licence",
-                    "type": "text/html",
-                    "title": ""
+                    "type": "text/html"
                 },
                 {
                     "href": "https://http://www.example.org/terms-and-conditions---datapoint#termsofservice",
                     "hreflang": "en",
                     "rel": "restrictions",
-                    "type": "text/html",
-                    "title": ""
+                    "type": "text/html"
                 },
                 {
                     "href": "http://www.example.org/edr/collections/3_hrly_fcst/instances",
                     "hreflang": "en",
-                    "rel": "collection",
-                    "title": ""
+                    "rel": "collection"
                 }
             ],
             "extent": {
@@ -634,6 +660,6 @@ There are also links to the license information for the observation and forecast
             }
         }
     ]
-}
+}    
 ----
 =================

--- a/candidate-standard/examples/collections_metadata_JSON_1.adoc
+++ b/candidate-standard/examples/collections_metadata_JSON_1.adoc
@@ -76,7 +76,6 @@ There are also links to the license information for the observation and forecast
                     "href": "http://www.example.org/edr/collections/hrly_obs/position",
                     "hreflang": "en",
                     "rel": "data",
-                    "type": "position",
                     "title": "",
                     "variables": {
                         "title": "Position query",
@@ -99,7 +98,6 @@ There are also links to the license information for the observation and forecast
                     "href": "http://www.example.org/edr/collections/hrly_obs/radius",
                     "hreflang": "en",
                     "rel": "data",
-                    "type": "radius",
                     "title": "",
                     "variables": {
                         "title": "Radius query",
@@ -126,7 +124,6 @@ There are also links to the license information for the observation and forecast
                     "href": "http://www.example.org/edr/collections/hrly_obs/area",
                     "hreflang": "en",
                     "rel": "data",
-                    "type": "area",
                     "title": "",
                     "variables": {
                         "title": "Area query",
@@ -150,7 +147,6 @@ There are also links to the license information for the observation and forecast
                     "href": "http://www.example.org/edr/collections/hrly_obs/locations",
                     "hreflang": "en",
                     "rel": "data",
-                    "type": "location",
                     "title": ""
                 }
             ],
@@ -414,7 +410,6 @@ There are also links to the license information for the observation and forecast
                     "href": "http://www.example.org/edr/collections/3_hrly_fcst/instances",
                     "hreflang": "en",
                     "rel": "collection",
-                    "type": "instances",
                     "title": ""
                 }
             ],

--- a/candidate-standard/examples/collections_metadata_JSON_1.adoc
+++ b/candidate-standard/examples/collections_metadata_JSON_1.adoc
@@ -555,7 +555,7 @@ There are also links to the license information for the observation and forecast
                 "CoverageJSON",
                 "GeoJSON"
             ],
-            "parameters": {
+            "parameter-names": {
                 "Wind Direction": {
                     "type": "Parameter",
                     "description": {

--- a/candidate-standard/examples/collections_metadata_JSON_1.adoc
+++ b/candidate-standard/examples/collections_metadata_JSON_1.adoc
@@ -119,21 +119,21 @@ There are also links to the license information for the observation and forecast
                 }
             },
             "crs": [
-                "EPSG:4326"
+                "CRS84"
             ],
-            "dataQueries": {
+            "data-queries": {
                 "position": {
                     "title": "Position query",
                     "description": "Position query",
-                    "outputformat": [
+                    "output-formats": [
                         "CoverageJSON",
                         "GeoJSON",
                         "IWXXM"
                     ],
-                    "defaultOutputFormat": "IWXXM",
-                    "crs": [
+                    "default-output-format": "IWXXM",
+                    "crs-details": [
                         {
-                            "name": "CRS84",
+                            "crs": "CRS84",
                             "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
                         }
                     ]
@@ -141,19 +141,19 @@ There are also links to the license information for the observation and forecast
                 "radius": {
                     "title": "Radius query",
                     "description": "Radius query",
-                    "outputformat": [
+                    "output-formats": [
                         "CoverageJSON",
                         "GeoJSON",
                         "IWXXM"
                     ],
-                    "defaultOutputFormat": "GeoJSON",
+                    "default-output-format": "GeoJSON",
                     "width-units": [
                         "km",
                         "miles"
                     ],
-                    "crs": [
+                    "crs-details": [
                         {
-                            "name": "CRS84",
+                            "crs": "CRS84",
                             "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
                         }
                     ]
@@ -161,22 +161,22 @@ There are also links to the license information for the observation and forecast
                 "area": {
                     "title": "Area query",
                     "description": "Area query",
-                    "outputformat": [
+                    "output-formats": [
                         "CoverageJSON",
                         "GeoJSON",
                         "BUFR",
                         "IWXXM"
                     ],
-                    "defaultOutputFormat": "CoverageJSON",
-                    "crs": [
+                    "default-output-format": "CoverageJSON",
+                    "crs-details": [
                         {
-                            "name": "CRS84",
+                            "crs": "CRS84",
                             "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
                         }
                     ]
                 }
             },
-            "outputformat": [
+            "output-formats": [
                 "CoverageJSON",
                 "GeoJSON",
                 "IWXXM"
@@ -184,13 +184,9 @@ There are also links to the license information for the observation and forecast
             "parameters": {
                 "Wind Direction": {
                     "type": "Parameter",
-                    "description": {
-                        "en": ""
-                    },
+                    "description": "",
                     "unit": {
-                        "label": {
-                            "en": "degree true"
-                        },
+                        "label": "degree true",
                         "symbol": {
                             "value": "°",
                             "type": "http://www.example.org/edr/metadata/units/degree"
@@ -198,9 +194,7 @@ There are also links to the license information for the observation and forecast
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/common/quantity-kind/_windDirection",
-                        "label": {
-                            "en": "Wind Direction"
-                        }
+                        "label":  "Wind Direction"
                     },
                     "measurementType": {
                         "method": "mean",
@@ -209,13 +203,9 @@ There are also links to the license information for the observation and forecast
                 },
                 "Wind Speed": {
                     "type": "Parameter",
-                    "description": {
-                        "en": ""
-                    },
+                    "description": "",
                     "unit": {
-                        "label": {
-                            "en": "mph"
-                        },
+                        "label": "mph",
                         "symbol": {
                             "value": "mph",
                             "type": "http://www.example.org/edr/metadata/units/mph"
@@ -223,9 +213,7 @@ There are also links to the license information for the observation and forecast
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/common/quantity-kind/_windSpeed",
-                        "label": {
-                            "en": "Wind Speed"
-                        }
+                        "label": "Wind Speed"
                     },
                     "measurementType": {
                         "method": "mean",
@@ -234,13 +222,9 @@ There are also links to the license information for the observation and forecast
                 },
                 "Wind Gust": {
                     "type": "Parameter",
-                    "description": {
-                        "en": ""
-                    },
+                    "description": "",
                     "unit": {
-                        "label": {
-                            "en": "mph"
-                        },
+                        "label": "mph",
                         "symbol": {
                             "value": "mph",
                             "type": "http://www.example.org/edr/metadata/units/mph"
@@ -248,9 +232,7 @@ There are also links to the license information for the observation and forecast
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/common/quantity-kind/_maximumWindGustSpeed",
-                        "label": {
-                            "en": "Wind Gust"
-                        }
+                        "label": "Wind Gust"
                     },
                     "measurementType": {
                         "method": "maximum",
@@ -259,13 +241,9 @@ There are also links to the license information for the observation and forecast
                 },
                 "Air Temperature": {
                     "type": "Parameter",
-                    "description": {
-                        "en": ""
-                    },
+                    "description": "",
                     "unit": {
-                        "label": {
-                            "en": "degC"
-                        },
+                        "label":  "degC",
                         "symbol": {
                             "value": "°C",
                             "type": "http://www.example.org/edr/metadata/units/degC"
@@ -273,9 +251,7 @@ There are also links to the license information for the observation and forecast
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/common/quantity-kind/_airTemperature",
-                        "label": {
-                            "en": "Air Temperature"
-                        }
+                        "label": "Air Temperature"
                     },
                     "measurementType": {
                         "method": "instantaneous",
@@ -284,13 +260,9 @@ There are also links to the license information for the observation and forecast
                 },
                 "Weather": {
                     "type": "Parameter",
-                    "description": {
-                        "en": ""
-                    },
+                    "description": "",
                     "unit": {
-                        "label": {
-                            "en": "weather"
-                        },
+                        "label": "weather",
                         "symbol": {
                             "value": "",
                             "type": "http://www.example.org/edr/metadata/lookup/mo_dp_weather"
@@ -298,9 +270,7 @@ There are also links to the license information for the observation and forecast
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/wmdr/ObservedVariableAtmosphere/_266",
-                        "label": {
-                            "en": "Weather"
-                        }
+                        "label": "Weather"
                     },
                     "measurementType": {
                         "method": "instantaneous",
@@ -309,13 +279,9 @@ There are also links to the license information for the observation and forecast
                 },
                 "Relative Humidity": {
                     "type": "Parameter",
-                    "description": {
-                        "en": ""
-                    },
+                    "description": "",
                     "unit": {
-                        "label": {
-                            "en": "percent"
-                        },
+                        "label": "percent",
                         "symbol": {
                             "value": "%",
                             "type": "http://www.example.org/edr/metadata/units/percent"
@@ -323,9 +289,7 @@ There are also links to the license information for the observation and forecast
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/bufr4/b/13/_009",
-                        "label": {
-                            "en": "Relative Humidity"
-                        }
+                        "label": "Relative Humidity"
                     },
                     "measurementType": {
                         "method": "instantaneous",
@@ -334,13 +298,9 @@ There are also links to the license information for the observation and forecast
                 },
                 "Dew point": {
                     "type": "Parameter",
-                    "description": {
-                        "en": ""
-                    },
+                    "description": "",
                     "unit": {
-                        "label": {
-                            "en": "degC"
-                        },
+                        "label": "degC",
                         "symbol": {
                             "value": "°C",
                             "type": "http://www.example.org/edr/metadata/units/degC"
@@ -348,9 +308,7 @@ There are also links to the license information for the observation and forecast
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/common/quantity-kind/_dewPointTemperature",
-                        "label": {
-                            "en": "Dew point"
-                        }
+                        "label": "Dew point"
                     },
                     "measurementType": {
                         "method": "instantaneous",
@@ -359,13 +317,9 @@ There are also links to the license information for the observation and forecast
                 },
                 "Pressure": {
                     "type": "Parameter",
-                    "description": {
-                        "en": ""
-                    },
+                    "description": "",
                     "unit": {
-                        "label": {
-                            "en": "hPa"
-                        },
+                        "label": "hPa",
                         "symbol": {
                             "value": "hPa",
                             "type": "http://www.example.org/edr/metadata/units/hPa"
@@ -373,9 +327,7 @@ There are also links to the license information for the observation and forecast
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/bufr4/b/10/_051",
-                        "label": {
-                            "en": "Pressure"
-                        }
+                        "label": "Pressure"
                     },
                     "measurementType": {
                         "method": "instantaneous",
@@ -384,13 +336,9 @@ There are also links to the license information for the observation and forecast
                 },
                 "Pressure Tendancy": {
                     "type": "Parameter",
-                    "description": {
-                        "en": ""
-                    },
+                    "description": "",
                     "unit": {
-                        "label": {
-                            "en": "tendency"
-                        },
+                        "label": "tendency",
                         "symbol": {
                             "value": "",
                             "type": "http://www.example.org/edr/metadata/units/hPa"
@@ -398,9 +346,7 @@ There are also links to the license information for the observation and forecast
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/common/quantity-kind/_pressureTendency",
-                        "label": {
-                            "en": "Pressure Tendancy"
-                        }
+                        "label": "Pressure Tendancy"
                     },
                     "measurementType": {
                         "method": "instantaneous",
@@ -409,13 +355,9 @@ There are also links to the license information for the observation and forecast
                 },
                 "Visibility": {
                     "type": "Parameter",
-                    "description": {
-                        "en": ""
-                    },
+                    "description": "",
                     "unit": {
-                        "label": {
-                            "en": "m"
-                        },
+                        "label": "m",
                         "symbol": {
                             "value": "m",
                             "type": "http://www.example.org/edr/metadata/units/m"
@@ -423,9 +365,7 @@ There are also links to the license information for the observation and forecast
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/common/quantity-kind/_horizontalVisibility",
-                        "label": {
-                            "en": "Visibility"
-                        }
+                        "label": "Visibility"
                     },
                     "measurementType": {
                         "method": "instantaneous",
@@ -498,20 +438,20 @@ There are also links to the license information for the observation and forecast
                 }
             },
             "crs": [
-                "EPSG:4326"
+                "CRS84"
             ],
-            "dataQueries": {
+            "data-queries": {
                 "position": {
                     "title": "Position query",
                     "description": "Position query",
-                    "outputformat": [
+                    "output-formats": [
                         "CoverageJSON",
                         "GeoJSON"
                     ],
-                    "defaultOutputFormat": "GeoJSON",
-                    "crs": [
+                    "default-output-format": "GeoJSON",
+                    "crs-details": [
                         {
-                            "name": "CRS84",
+                            "crs": "CRS84",
                             "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
                         }
                     ]
@@ -519,18 +459,18 @@ There are also links to the license information for the observation and forecast
                 "radius": {
                     "title": "Radius query",
                     "description": "Radius query",
-                    "outputformat": [
+                    "output-formats": [
                         "CoverageJSON",
                         "GeoJSON"
                     ],
-                    "defaultOutputFormat": "GeoJSON",
+                    "default-output-format": "GeoJSON",
                     "width-units": [
                         "km",
                         "miles"
                     ],
-                    "crs": [
+                    "crs-details": [
                         {
-                            "name": "CRS84",
+                            "crs": "CRS84",
                             "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
                         }
                     ]
@@ -538,33 +478,29 @@ There are also links to the license information for the observation and forecast
                 "area": {
                     "title": "Area query",
                     "description": "Area query",
-                    "outputformat": [
+                    "output-formats": [
                         "CoverageJSON",
                         "GeoJSON"
                     ],
-                    "defaultOutputFormat": "CoverageJSON",
-                    "crs": [
+                    "default-output-format": "CoverageJSON",
+                    "crs-details": [
                         {
-                            "name": "CRS84",
+                            "crs": "CRS84",
                             "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
                         }
                     ]
                 }
             },
-            "outputformat": [
+            "output-formats": [
                 "CoverageJSON",
                 "GeoJSON"
             ],
             "parameter-names": {
                 "Wind Direction": {
                     "type": "Parameter",
-                    "description": {
-                        "en": "Direction wind is from"
-                    },
+                    "description": "Direction wind is from",
                     "unit": {
-                        "label": {
-                            "en": "degree true"
-                        },
+                        "label": "degree true",
                         "symbol": {
                             "value": "°",
                             "type": "http://www.example.org/edr/metadata/units/degree"
@@ -572,10 +508,8 @@ There are also links to the license information for the observation and forecast
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/grib2/codeflag/4.2/_0-2-0",
-                        "label": {
-                            "en": "Wind Direction"
-                        }
-                    },
+                        "label": "Wind Direction"
+                                            },
                     "measurementType": {
                         "method": "mean",
                         "period": "-PT10M/PT0M"
@@ -583,13 +517,9 @@ There are also links to the license information for the observation and forecast
                 },
                 "Wind Speed": {
                     "type": "Parameter",
-                    "description": {
-                        "en": "Average wind speed"
-                    },
+                    "description":"Average wind speed",
                     "unit": {
-                        "label": {
-                            "en": "mph"
-                        },
+                        "label": "mph",
                         "symbol": {
                             "value": "mph",
                             "type": "http://www.example.org/edr/metadata/units/mph"
@@ -597,9 +527,7 @@ There are also links to the license information for the observation and forecast
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/grib2/codeflag/4.2/_0-2-1",
-                        "label": {
-                            "en": "Wind Speed"
-                        }
+                        "label":  "Wind Speed"
                     },
                     "measurementType": {
                         "method": "mean",
@@ -608,13 +536,9 @@ There are also links to the license information for the observation and forecast
                 },
                 "Wind Gust": {
                     "type": "Parameter",
-                    "description": {
-                        "en": "Wind gusts are a rapid increase in strength of the wind relative to the wind speed."
-                    },
+                    "description":  "Wind gusts are a rapid increase in strength of the wind relative to the wind speed.",
                     "unit": {
-                        "label": {
-                            "en": "mph"
-                        },
+                        "label": "mph",
                         "symbol": {
                             "value": "mph",
                             "type": "http://www.example.org/edr/metadata/units/mph"
@@ -622,9 +546,7 @@ There are also links to the license information for the observation and forecast
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/grib2/codeflag/4.2/_0-2-1",
-                        "label": {
-                            "en": "Wind Gust"
-                        }
+                        "label": "Wind Gust"
                     },
                     "measurementType": {
                         "method": "maximum",
@@ -633,13 +555,9 @@ There are also links to the license information for the observation and forecast
                 },
                 "Air Temperature": {
                     "type": "Parameter",
-                    "description": {
-                        "en": "2m air temperature in the shade and out of the wind"
-                    },
+                    "description":  "2m air temperature in the shade and out of the wind",
                     "unit": {
-                        "label": {
-                            "en": "degC"
-                        },
+                        "label":  "degC",
                         "symbol": {
                             "value": "°C",
                             "type": "http://www.example.org/edr/metadata/units/degC"
@@ -647,9 +565,7 @@ There are also links to the license information for the observation and forecast
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/common/quantity-kind/_airTemperature",
-                        "label": {
-                            "en": "Air Temperature"
-                        }
+                        "label": "Air Temperature"
                     },
                     "measurementType": {
                         "method": "instantaneous",
@@ -658,13 +574,9 @@ There are also links to the license information for the observation and forecast
                 },
                 "Weather": {
                     "type": "Parameter",
-                    "description": {
-                        "en": ""
-                    },
+                    "description": "",
                     "unit": {
-                        "label": {
-                            "en": "weather"
-                        },
+                        "label":  "weather",
                         "symbol": {
                             "value": "",
                             "type": "http://www.example.org/edr/metadata/lookup/mo_dp_weather"
@@ -672,9 +584,7 @@ There are also links to the license information for the observation and forecast
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/wmdr/ObservedVariableAtmosphere/_266",
-                        "label": {
-                            "en": "Weather"
-                        }
+                        "label": "Weather"
                     },
                     "measurementType": {
                         "method": "instantaneous",
@@ -683,13 +593,9 @@ There are also links to the license information for the observation and forecast
                 },
                 "Relative Humidity": {
                     "type": "Parameter",
-                    "description": {
-                        "en": ""
-                    },
+                    "description": "",
                     "unit": {
-                        "label": {
-                            "en": "percent"
-                        },
+                        "label": "percent",
                         "symbol": {
                             "value": "%",
                             "type": "http://www.example.org/edr/metadata/units/percent"
@@ -697,9 +603,7 @@ There are also links to the license information for the observation and forecast
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/grib2/codeflag/4.2/_0-1-1",
-                        "label": {
-                            "en": "Relative Humidity"
-                        }
+                        "label":  "Relative Humidity"
                     },
                     "measurementType": {
                         "method": "instantaneous",
@@ -708,13 +612,9 @@ There are also links to the license information for the observation and forecast
                 },
                 "Feels like temperature": {
                     "type": "Parameter",
-                    "description": {
-                        "en": ""
-                    },
+                    "description": "",
                     "unit": {
-                        "label": {
-                            "en": "degC"
-                        },
+                        "label": "degC",
                         "symbol": {
                             "value": "°C",
                             "type": "http://www.example.org/edr/metadata/units/degC"
@@ -722,9 +622,7 @@ There are also links to the license information for the observation and forecast
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/common/quantity-kind/_airTemperature",
-                        "label": {
-                            "en": "Feels like temperature"
-                        }
+                        "label": "Feels like temperature"
                     },
                     "measurementType": {
                         "method": "instantaneous",
@@ -733,13 +631,9 @@ There are also links to the license information for the observation and forecast
                 },
                 "UV index": {
                     "type": "Parameter",
-                    "description": {
-                        "en": ""
-                    },
+                    "description": "",
                     "unit": {
-                        "label": {
-                            "en": "UV_index"
-                        },
+                        "label":  "UV_index",
                         "symbol": {
                             "value": "",
                             "type": "http://www.example.org/edr/metadata/lookup/mo_dp_uv"
@@ -747,9 +641,7 @@ There are also links to the license information for the observation and forecast
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/grib2/codeflag/4.2/_0-4-51",
-                        "label": {
-                            "en": "UV index"
-                        }
+                        "label": "UV index"
                     },
                     "measurementType": {
                         "method": "instantaneous",
@@ -758,13 +650,9 @@ There are also links to the license information for the observation and forecast
                 },
                 "Probabilty of precipitation": {
                     "type": "Parameter",
-                    "description": {
-                        "en": ""
-                    },
+                    "description": "",
                     "unit": {
-                        "label": {
-                            "en": "percent"
-                        },
+                        "label": "percent",
                         "symbol": {
                             "value": "%",
                             "type": "http://www.example.org/edr/metadata/units/percent"
@@ -772,9 +660,7 @@ There are also links to the license information for the observation and forecast
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/grib2/codeflag/4.2/_0-1-1",
-                        "label": {
-                            "en": "Probabilty of precipitation"
-                        }
+                        "label": "Probabilty of precipitation"
                     },
                     "measurementType": {
                         "method": "instantaneous",
@@ -783,13 +669,9 @@ There are also links to the license information for the observation and forecast
                 },
                 "Visibility": {
                     "type": "Parameter",
-                    "description": {
-                        "en": ""
-                    },
+                    "description": "",
                     "unit": {
-                        "label": {
-                            "en": "quality"
-                        },
+                        "label": "quality",
                         "symbol": {
                             "value": "",
                             "type": "http://www.example.org/edr/metadata/lookup/mo_dp_visibility"
@@ -797,9 +679,7 @@ There are also links to the license information for the observation and forecast
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/common/quantity-kind/_horizontalVisibility",
-                        "label": {
-                            "en": "Visibility"
-                        }
+                        "label":  "Visibility"
                     },
                     "measurementType": {
                         "method": "instantaneous",

--- a/candidate-standard/examples/collections_metadata_JSON_1.adoc
+++ b/candidate-standard/examples/collections_metadata_JSON_1.adoc
@@ -80,6 +80,7 @@ There are also links to the license information for the observation and forecast
                     "variables": {
                         "title": "Position query",
                         "description": "Position query",
+                        "query_type": "position",
                         "output_formats": [
                             "CoverageJSON",
                             "GeoJSON",
@@ -102,6 +103,7 @@ There are also links to the license information for the observation and forecast
                     "variables": {
                         "title": "Radius query",
                         "description": "Radius query",
+                        "query_type": "radius",
                         "output_formats": [
                             "CoverageJSON",
                             "GeoJSON",
@@ -128,6 +130,7 @@ There are also links to the license information for the observation and forecast
                     "variables": {
                         "title": "Area query",
                         "description": "Area query",
+                        "query_type": "area",
                         "output_formats": [
                             "CoverageJSON",
                             "GeoJSON",
@@ -631,6 +634,6 @@ There are also links to the license information for the observation and forecast
             }
         }
     ]
-}    
+}
 ----
 =================

--- a/candidate-standard/examples/collections_metadata_JSON_1.adoc
+++ b/candidate-standard/examples/collections_metadata_JSON_1.adoc
@@ -70,114 +70,24 @@ There are also links to the license information for the observation and forecast
                     "type": "text/html"
                 },
                 {
-                    "href": "http://www.example.org/edr/collections/hrly_obs/position?coords={coords}",
+                    "href": "http://www.example.org/edr/collections/hrly_obs/position",
                     "hreflang": "en",
-                    "rel": "data",
-                    "title": "",
-                    "templated": true,
-                    "variables": {
-                        "title": "Position query",
-                        "description": "Position query",
-                        "query_type": "position",
-                        "coords" :{
-                            "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
-                        },
-                        "output_formats": [
-                            "CoverageJSON",
-                            "GeoJSON",
-                            "IWXXM"
-                        ],
-                        "default_output_format": "IWXXM",
-                        "crs_details": [
-                            {
-                                "crs": "CRS84",
-                                "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
-                            }
-                        ]    
-                    }
+                    "rel": "data"
                 },
                 {
-                    "href": "http://www.example.org/edr/collections/hrly_obs/radius?coords={coords}",
+                    "href": "http://www.example.org/edr/collections/hrly_obs/radius",
                     "hreflang": "en",
-                    "rel": "data",
-                    "title": "",
-                    "templated": true,
-                    "variables": {
-                        "title": "Radius query",
-                        "description": "Radius query",
-                        "query_type": "radius",
-                        "coords" :{
-                            "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
-                        },
-                        "output_formats": [
-                            "CoverageJSON",
-                            "GeoJSON",
-                            "IWXXM"
-                        ],
-                        "default_output_format": "GeoJSON",
-                        "within_units": [
-                            "km",
-                            "miles"
-                        ],
-                        "crs_details": [
-                            {
-                                "crs": "CRS84",
-                                "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
-                            }
-                        ]    
-                    }
+                    "rel": "data"
                 },
                 {
-                    "href": "http://www.example.org/edr/collections/hrly_obs/area?coords={coords}",
+                    "href": "http://www.example.org/edr/collections/hrly_obs/area",
                     "hreflang": "en",
-                    "rel": "data",
-                    "title": "",
-                    "templated": true,
-                    "variables": {
-                        "title": "Area query",
-                        "description": "Area query",
-                        "query_type": "area",
-                        "coords" :{
-                            "description": "Well Known Text POLYGON value i.e. POLYGON((-79 40,-79 38,-75 38,-75 41,-79 40))"
-                        },
-                        "output_formats": [
-                            "CoverageJSON",
-                            "GeoJSON",
-                            "BUFR",
-                            "IWXXM"
-                        ],
-                        "default_output_format": "CoverageJSON",
-                        "crs_details": [
-                            {
-                                "crs": "CRS84",
-                                "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
-                            }
-                        ]    
-                    }
+                    "rel": "data"
                 },
                 {
                     "href": "http://www.example.org/edr/collections/hrly_obs/locations",
                     "hreflang": "en",
-                    "rel": "data",
-                    "templated": false,
-                    "variables": {
-                        "title": "Location query",
-                        "description": "Location query",
-                        "query_type": "locations",
-                        "output_formats": [
-                            "CoverageJSON",
-                            "GeoJSON",
-                            "BUFR",
-                            "IWXXM"
-                        ],
-                        "default_output_format": "CoverageJSON",
-                        "crs_details": [
-                            {
-                                "crs": "CRS84",
-                                "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
-                            }
-                        ]    
-                    }
+                    "rel": "data"
                 }
             ],
             "extent": {
@@ -195,6 +105,123 @@ There are also links to the license information for the observation and forecast
                         "2020-04-19T11:00:00Z/2020-06-30T09:00:00Z"
                     ],
                     "trs": "TIMECRS[\"DateTime\",TDATUM[\"Gregorian Calendar\"],CS[TemporalDateTime,1],AXIS[\"Time (T)\",future]"
+                }
+            },
+            "data_queries" : {
+                "position": {
+                    "link": {
+                        "href": "http://www.example.org/edr/collections/hrly_obs/position?coords={coords}",
+                        "hreflang": "en",
+                        "rel": "data",
+                        "templated": true,
+                        "variables": {
+                            "title": "Position query",
+                            "description": "Position query",
+                            "query_type": "position",
+                            "coords" :{
+                                "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
+                            },
+                            "output_formats": [
+                                "CoverageJSON",
+                                "GeoJSON",
+                                "IWXXM"
+                            ],
+                            "default_output_format": "IWXXM",
+                            "crs_details": [
+                                {
+                                    "crs": "CRS84",
+                                    "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
+                                }
+                            ]    
+                        }
+                    }                    
+                },
+                "radius": {
+                    "link": {
+                        "href": "http://www.example.org/edr/collections/hrly_obs/radius?coords={coords}",
+                        "hreflang": "en",
+                        "rel": "data",
+                        "templated": true,
+                        "variables": {
+                            "title": "Radius query",
+                            "description": "Radius query",
+                            "query_type": "radius",
+                            "coords" :{
+                                "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
+                            },
+                            "output_formats": [
+                                "CoverageJSON",
+                                "GeoJSON",
+                                "IWXXM"
+                            ],
+                            "default_output_format": "GeoJSON",
+                            "within_units": [
+                                "km",
+                                "miles"
+                            ],
+                            "crs_details": [
+                                {
+                                    "crs": "CRS84",
+                                    "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
+                                }
+                            ]    
+                        }
+                    }                  
+                },
+                "area": {
+                    "link":                 {
+                        "href": "http://www.example.org/edr/collections/hrly_obs/area?coords={coords}",
+                        "hreflang": "en",
+                        "rel": "data",
+                        "templated": true,
+                        "variables": {
+                            "title": "Area query",
+                            "description": "Area query",
+                            "query_type": "area",
+                            "coords" :{
+                                "description": "Well Known Text POLYGON value i.e. POLYGON((-79 40,-79 38,-75 38,-75 41,-79 40))"
+                            },
+                            "output_formats": [
+                                "CoverageJSON",
+                                "GeoJSON",
+                                "BUFR",
+                                "IWXXM"
+                            ],
+                            "default_output_format": "CoverageJSON",
+                            "crs_details": [
+                                {
+                                    "crs": "CRS84",
+                                    "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
+                                }
+                            ]    
+                        }
+                    }
+                },
+                "locations": {
+                    "link": {
+                        "href": "http://www.example.org/edr/collections/hrly_obs/locations",
+                        "hreflang": "en",
+                        "rel": "data",
+                        "templated": false,
+                        "variables": {
+                            "title": "Location query",
+                            "description": "Location query",
+                            "query_type": "locations",
+                            "output_formats": [
+                                "CoverageJSON",
+                                "GeoJSON",
+                                "BUFR",
+                                "IWXXM"
+                            ],
+                            "default_output_format": "CoverageJSON",
+                            "crs_details": [
+                                {
+                                    "crs": "CRS84",
+                                    "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
+                                }
+                            ]    
+                        }
+                    }                    
                 }
             },
             "crs": [
@@ -657,6 +684,6 @@ There are also links to the license information for the observation and forecast
             }
         }
     ]
-}    
+}      
 ----
 =================

--- a/candidate-standard/examples/collections_metadata_JSON_1.adoc
+++ b/candidate-standard/examples/collections_metadata_JSON_1.adoc
@@ -55,33 +55,30 @@ There are also links to the license information for the observation and forecast
                     "href": "http://www.example.org/uk-hourly-site-specific-observations",
                     "hreflang": "en",
                     "rel": "service-doc",
-                    "type": "text/html",
-                    "title": ""
+                    "type": "text/html"
                 },
                 {
                     "href": "http://www.example.org/terms-and-conditions---datapoint#datalicence",
                     "hreflang": "en",
                     "rel": "license",
-                    "type": "text/html",
-                    "title": ""
+                    "type": "text/html"
                 },
                 {
                     "href": "https://www.metoffice.gov.uk/services/data/datapoint/terms-and-conditions---datapoint#termsofservice",
                     "hreflang": "en",
                     "rel": "restrictions",
-                    "type": "text/html",
-                    "title": ""
+                    "type": "text/html"
                 },
                 {
                     "href": "http://www.example.org/edr/collections/hrly_obs/position?coords={coords}",
                     "hreflang": "en",
                     "rel": "data",
                     "title": "",
+                    "templated": true,
                     "variables": {
                         "title": "Position query",
                         "description": "Position query",
                         "query_type": "position",
-                        "templated": true,
                         "coords" :{
                             "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
                         },
@@ -104,11 +101,11 @@ There are also links to the license information for the observation and forecast
                     "hreflang": "en",
                     "rel": "data",
                     "title": "",
+                    "templated": true,
                     "variables": {
                         "title": "Radius query",
                         "description": "Radius query",
                         "query_type": "radius",
-                        "templated": true,
                         "coords" :{
                             "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
                         },
@@ -135,11 +132,11 @@ There are also links to the license information for the observation and forecast
                     "hreflang": "en",
                     "rel": "data",
                     "title": "",
+                    "templated": true,
                     "variables": {
                         "title": "Area query",
                         "description": "Area query",
                         "query_type": "area",
-                        "templated": true,
                         "coords" :{
                             "description": "Well Known Text POLYGON value i.e. POLYGON((-79 40,-79 38,-75 38,-75 41,-79 40))"
                         },
@@ -162,11 +159,11 @@ There are also links to the license information for the observation and forecast
                     "href": "http://www.example.org/edr/collections/hrly_obs/locations",
                     "hreflang": "en",
                     "rel": "data",
+                    "templated": false,
                     "variables": {
                         "title": "Location query",
                         "description": "Location query",
-                        "query_type": "location",
-                        "templated": false,
+                        "query_type": "locations",
                         "output_formats": [
                             "CoverageJSON",
                             "GeoJSON",

--- a/candidate-standard/examples/collections_metadata_JSON_1.adoc
+++ b/candidate-standard/examples/collections_metadata_JSON_1.adoc
@@ -115,7 +115,7 @@ There are also links to the license information for the observation and forecast
                             "IWXXM"
                         ],
                         "default_output_format": "GeoJSON",
-                        "width_units": [
+                        "within_units": [
                             "km",
                             "miles"
                         ],

--- a/candidate-standard/examples/instance_metadata_JSON.adoc
+++ b/candidate-standard/examples/instance_metadata_JSON.adoc
@@ -119,7 +119,7 @@ There are also links to the license information for the observation and forecast
                             "CSV"
                         ],
                         "default_output_format": "GeoJSON",
-                        "width_units": [
+                        "within_units": [
                             "km",
                             "miles"
                         ],
@@ -459,7 +459,7 @@ There are also links to the license information for the observation and forecast
                             "CSV"
                         ],
                         "default_output_format": "GeoJSON",
-                        "width_units": [
+                        "within_units": [
                             "km",
                             "miles"
                         ],
@@ -800,7 +800,7 @@ There are also links to the license information for the observation and forecast
                             "CSV"
                         ],
                         "default_output_format": "GeoJSON",
-                        "width_units": [
+                        "within_units": [
                             "km",
                             "miles"
                         ],
@@ -1140,7 +1140,7 @@ There are also links to the license information for the observation and forecast
                             "CSV"
                         ],
                         "default_output_format": "GeoJSON",
-                        "width_units": [
+                        "within_units": [
                             "km",
                             "miles"
                         ],

--- a/candidate-standard/examples/instance_metadata_JSON.adoc
+++ b/candidate-standard/examples/instance_metadata_JSON.adoc
@@ -79,11 +79,11 @@ There are also links to the license information for the observation and forecast
                     "hreflang": "en",
                     "rel": "data",
                     "title": "",
+                    "templated": true,
                     "variables": {
                         "title": "Position query",
                         "description": "Position query",
                         "query_type": "position",
-                        "templated": true,
                         "coords" :{
                             "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
                         },                        
@@ -105,11 +105,11 @@ There are also links to the license information for the observation and forecast
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/radius?coords={coords}",
                     "hreflang": "en",
                     "rel": "data",
+                    "templated": true,
                     "variables": {
                         "title": "Radius query",
                         "description": "Radius query",
                         "query_type": "radius",
-                        "templated": true,
                         "coords" :{
                             "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
                         },                        
@@ -136,11 +136,11 @@ There are also links to the license information for the observation and forecast
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/area?coords={coords}",
                     "hreflang": "en",
                     "rel": "data",
+                    "templated": true,
                     "variables": {
                         "title": "Area query",
                         "description": "Area query",
                         "query_type": "area",
-                        "templated": true,
                         "coords" :{
                             "description": "Well Known Text POLYGON value i.e. POLYGON((-79 40,-79 38,-75 38,-75 41,-79 40))"
                         },
@@ -163,11 +163,11 @@ There are also links to the license information for the observation and forecast
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/locations",
                     "hreflang": "en",
                     "rel": "data",
+                    "templated": false,
                     "variables": {
                         "title": "Locations query",
                         "description": "Locations query",
                         "query_type": "location",
-                        "templated": false,
                         "output_formats": [
                             "CoverageJSON",
                             "GeoJSON"
@@ -419,11 +419,11 @@ There are also links to the license information for the observation and forecast
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/position?coords={coords}",
                     "hreflang": "en",
                     "rel": "data",
+                    "templated": true,
                     "variables": {
                         "title": "Position query",
                         "description": "Position query",
                         "query_type": "position",
-                        "templated": true,
                         "coords" :{
                             "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
                         },                        
@@ -445,12 +445,11 @@ There are also links to the license information for the observation and forecast
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/radius?coords={coords}",
                     "hreflang": "en",
                     "rel": "data",
-                    "title": "",
+                    "templated": true,
                     "variables": {
                         "title": "Radius query",
                         "description": "Radius query",
                         "query_type": "radius",
-                        "templated": true,
                         "coords" :{
                             "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
                         },
@@ -478,11 +477,11 @@ There are also links to the license information for the observation and forecast
                     "hreflang": "en",
                     "rel": "data",
                     "title": "",
+                    "templated": true,
                     "variables": {
                         "title": "Area query",
                         "description": "Area query",
                         "query_type": "area",
-                        "templated": true,
                         "coords" :{
                             "description": "Well Known Text POLYGON value i.e. POLYGON((-79 40,-79 38,-75 38,-75 41,-79 40))"
                         },
@@ -505,11 +504,11 @@ There are also links to the license information for the observation and forecast
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/locations",
                     "hreflang": "en",
                     "rel": "data",
+                    "templated": false,
                     "variables": {
                         "title": "Locations query",
                         "description": "Locations query",
                         "query_type": "location",
-                        "templated": false,
                         "output_formats": [
                             "CoverageJSON",
                             "GeoJSON"
@@ -761,11 +760,11 @@ There are also links to the license information for the observation and forecast
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/position?coords={coords}",
                     "hreflang": "en",
                     "rel": "data",
+                    "templated": true,
                     "variables": {
                         "title": "Position query",
                         "description": "Position query",
                         "query_type": "position",
-                        "templated": true,
                         "coords" :{
                             "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
                         },
@@ -787,11 +786,11 @@ There are also links to the license information for the observation and forecast
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/radius?coords={coords}",
                     "hreflang": "en",
                     "rel": "data",
+                    "templated": true,
                     "variables": {
                         "title": "Radius query",
                         "description": "Radius query",
                         "query_type": "radius",
-                        "templated": true,
                         "coords" :{
                             "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
                         },
@@ -818,11 +817,11 @@ There are also links to the license information for the observation and forecast
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/area?coords={coords}",
                     "hreflang": "en",
                     "rel": "data",
+                    "templated": true,
                     "variables": {
                         "title": "Area query",
                         "description": "Area query",
                         "query_type": "area",
-                        "templated": true,
                         "coords" :{
                             "description": "Well Known Text POLYGON value i.e. POLYGON((-79 40,-79 38,-75 38,-75 41,-79 40))"
                         },
@@ -845,11 +844,11 @@ There are also links to the license information for the observation and forecast
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/locations",
                     "hreflang": "en",
                     "rel": "data",
+                    "templated": false,
                     "variables": {
                         "title": "Locations query",
                         "description": "Locations query",
                         "query_type": "location",
-                        "templated": false,
                         "output_formats": [
                             "CoverageJSON",
                             "GeoJSON"
@@ -1101,11 +1100,11 @@ There are also links to the license information for the observation and forecast
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/position?coords={coords}",
                     "hreflang": "en",
                     "rel": "data",
+                    "templated": true,
                     "variables": {
                         "title": "Position query",
                         "description": "Position query",
                         "query_type": "position",
-                        "templated": true,
                         "coords" :{
                             "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
                         },
@@ -1127,12 +1126,11 @@ There are also links to the license information for the observation and forecast
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/radius?coords={coords}",
                     "hreflang": "en",
                     "rel": "data",
-                    "title": "",
+                    "templated": true,
                     "variables": {
                         "title": "Radius query",
                         "description": "Radius query",
                         "query_type": "radius",
-                        "templated": true,
                         "coords" :{
                             "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
                         },
@@ -1159,11 +1157,11 @@ There are also links to the license information for the observation and forecast
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/area?coords={coords}",
                     "hreflang": "en",
                     "rel": "data",
+                    "templated": true,
                     "variables": {
                         "title": "Area query",
                         "description": "Area query",
                         "query_type": "area",
-                        "templated": true,
                         "coords" :{
                             "description": "Well Known Text POLYGON value i.e. POLYGON((-79 40,-79 38,-75 38,-75 41,-79 40))"
                         },
@@ -1186,11 +1184,11 @@ There are also links to the license information for the observation and forecast
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/locations",
                     "hreflang": "en",
                     "rel": "data",
+                    "templated": false,
                     "variables": {
                         "title": "Locations query",
                         "description": "Locations query",
                         "query_type": "location",
-                        "templated": false,
                         "output_formats": [
                             "CoverageJSON",
                             "GeoJSON"

--- a/candidate-standard/examples/instance_metadata_JSON.adoc
+++ b/candidate-standard/examples/instance_metadata_JSON.adoc
@@ -75,111 +75,24 @@ There are also links to the license information for the observation and forecast
             ],
             "links": [
                 {
-                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/position?coords={coords}",
+                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/position",
                     "hreflang": "en",
-                    "rel": "data",
-                    "title": "",
-                    "templated": true,
-                    "variables": {
-                        "title": "Position query",
-                        "description": "Position query",
-                        "query_type": "position",
-                        "coords" :{
-                            "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
-                        },                        
-                        "output_formats": [
-                            "CoverageJSON",
-                            "GeoJSON"
-                        ],
-                        "default_output_format": "GeoJSON",
-                        "crs_details": [
-                            {
-                                "crs": "CRS84",
-                                "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
-                            }
-                        ]    
-                    }
-
+                    "rel": "data"
                 },
                 {
-                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/radius?coords={coords}",
+                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/radius",
                     "hreflang": "en",
-                    "rel": "data",
-                    "templated": true,
-                    "variables": {
-                        "title": "Radius query",
-                        "description": "Radius query",
-                        "query_type": "radius",
-                        "coords" :{
-                            "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
-                        },                        
-                        "output_formats": [
-                            "CoverageJSON",
-                            "GeoJSON",
-                            "CSV"
-                        ],
-                        "default_output_format": "GeoJSON",
-                        "within_units": [
-                            "km",
-                            "miles"
-                        ],
-                        "crs_details": [
-                            {
-                                "crs": "CRS84",
-                                "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
-                            }
-                        ]    
-                    }
-
+                    "rel": "data"
                 },
                 {
-                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/area?coords={coords}",
+                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/area",
                     "hreflang": "en",
-                    "rel": "data",
-                    "templated": true,
-                    "variables": {
-                        "title": "Area query",
-                        "description": "Area query",
-                        "query_type": "area",
-                        "coords" :{
-                            "description": "Well Known Text POLYGON value i.e. POLYGON((-79 40,-79 38,-75 38,-75 41,-79 40))"
-                        },
-                        "output_formats": [
-                            "CoverageJSON",
-                            "GeoJSON",
-                            "CSV"
-                        ],
-                        "default_output_format": "CoverageJSON",
-                        "crs_details": [
-                            {
-                                "crs": "CRS84",
-                                "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
-                            }
-                        ]    
-                    }
-                    
+                    "rel": "data"
                 },
                 {
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/locations",
                     "hreflang": "en",
-                    "rel": "data",
-                    "templated": false,
-                    "variables": {
-                        "title": "Locations query",
-                        "description": "Locations query",
-                        "query_type": "location",
-                        "output_formats": [
-                            "CoverageJSON",
-                            "GeoJSON"
-                        ],
-                        "default_output_format": "GeoJSON",
-                        "crs_details": [
-                            {
-                                "crs": "CRS84",
-                                "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
-                            }
-                        ]    
-                    }
+                    "rel": "data"
                 }
             ],
             "extent": {
@@ -199,7 +112,123 @@ There are also links to the license information for the observation and forecast
                     "trs": "TIMECRS[\"DateTime\",TDATUM[\"Gregorian Calendar\"],CS[TemporalDateTime,1],AXIS[\"Time (T)\",future]"
                 }
             },
-            "crs": ["CRS84"],
+            "data_queries": {
+                "position": {
+                    "link": {
+                        "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/position?coords={coords}",
+                        "hreflang": "en",
+                        "rel": "data",
+                        "title": "",
+                        "templated": true,
+                        "variables": {
+                            "title": "Position query",
+                            "description": "Position query",
+                            "query_type": "position",
+                            "coords": {
+                                "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
+                            },
+                            "output_formats": [
+                                "CoverageJSON",
+                                "GeoJSON"
+                            ],
+                            "default_output_format": "GeoJSON",
+                            "crs_details": [
+                                {
+                                    "crs": "CRS84",
+                                    "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "radius": {
+                    "link": {
+                        "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/radius?coords={coords}",
+                        "hreflang": "en",
+                        "rel": "data",
+                        "templated": true,
+                        "variables": {
+                            "title": "Radius query",
+                            "description": "Radius query",
+                            "query_type": "radius",
+                            "coords": {
+                                "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
+                            },
+                            "output_formats": [
+                                "CoverageJSON",
+                                "GeoJSON",
+                                "CSV"
+                            ],
+                            "default_output_format": "GeoJSON",
+                            "within_units": [
+                                "km",
+                                "miles"
+                            ],
+                            "crs_details": [
+                                {
+                                    "crs": "CRS84",
+                                    "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "area": {
+                    "link": {
+                        "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/area?coords={coords}",
+                        "hreflang": "en",
+                        "rel": "data",
+                        "templated": true,
+                        "variables": {
+                            "title": "Area query",
+                            "description": "Area query",
+                            "query_type": "area",
+                            "coords": {
+                                "description": "Well Known Text POLYGON value i.e. POLYGON((-79 40,-79 38,-75 38,-75 41,-79 40))"
+                            },
+                            "output_formats": [
+                                "CoverageJSON",
+                                "GeoJSON",
+                                "CSV"
+                            ],
+                            "default_output_format": "CoverageJSON",
+                            "crs_details": [
+                                {
+                                    "crs": "CRS84",
+                                    "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "locations": {
+                    "link": {
+                        "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/locations",
+                        "hreflang": "en",
+                        "rel": "data",
+                        "templated": false,
+                        "variables": {
+                            "title": "Locations query",
+                            "description": "Locations query",
+                            "query_type": "location",
+                            "output_formats": [
+                                "CoverageJSON",
+                                "GeoJSON"
+                            ],
+                            "default_output_format": "GeoJSON",
+                            "crs_details": [
+                                {
+                                    "crs": "CRS84",
+                                    "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            "crs": [
+                "CRS84"
+            ],
             "output_formats": [
                 "GeoJSON",
                 "CoverageJSON",
@@ -218,7 +247,7 @@ There are also links to the license information for the observation and forecast
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/grib2/codeflag/4.2/_0-2-0",
-                        "label":  "Wind Direction"
+                        "label": "Wind Direction"
                     },
                     "measurementType": {
                         "method": "mean",
@@ -229,7 +258,7 @@ There are also links to the license information for the observation and forecast
                     "type": "Parameter",
                     "description": "Average wind speed",
                     "unit": {
-                        "label":  "mph",
+                        "label": "mph",
                         "symbol": {
                             "value": "mph",
                             "type": "http://http://www.example.org/edr/metadata/units/mph"
@@ -248,7 +277,7 @@ There are also links to the license information for the observation and forecast
                     "type": "Parameter",
                     "description": "Wind gusts are a rapid increase in strength of the wind relative to the wind speed.",
                     "unit": {
-                        "label":  "mph",
+                        "label": "mph",
                         "symbol": {
                             "value": "mph",
                             "type": "http://http://www.example.org/edr/metadata/units/mph"
@@ -286,7 +315,7 @@ There are also links to the license information for the observation and forecast
                     "type": "Parameter",
                     "description": "",
                     "unit": {
-                        "label":  "weather",
+                        "label": "weather",
                         "symbol": {
                             "value": "",
                             "type": "http://http://www.example.org/edr/metadata/lookup/mo_dp_weather"
@@ -305,7 +334,7 @@ There are also links to the license information for the observation and forecast
                     "type": "Parameter",
                     "description": "",
                     "unit": {
-                        "label":  "percent",
+                        "label": "percent",
                         "symbol": {
                             "value": "%",
                             "type": "http://http://www.example.org/edr/metadata/units/percent"
@@ -313,7 +342,7 @@ There are also links to the license information for the observation and forecast
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/grib2/codeflag/4.2/_0-1-1",
-                        "label":  "Relative Humidity"
+                        "label": "Relative Humidity"
                     },
                     "measurementType": {
                         "method": "instantaneous",
@@ -324,7 +353,7 @@ There are also links to the license information for the observation and forecast
                     "type": "Parameter",
                     "description": "",
                     "unit": {
-                        "label":  "degC",
+                        "label": "degC",
                         "symbol": {
                             "value": "°C",
                             "type": "http://http://www.example.org/edr/metadata/units/degC"
@@ -332,7 +361,7 @@ There are also links to the license information for the observation and forecast
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/common/quantity-kind/_airTemperature",
-                        "label":  "Feels like temperature"
+                        "label": "Feels like temperature"
                     },
                     "measurementType": {
                         "method": "instantaneous",
@@ -343,7 +372,7 @@ There are also links to the license information for the observation and forecast
                     "type": "Parameter",
                     "description": "",
                     "unit": {
-                        "label":  "UV_index",
+                        "label": "UV_index",
                         "symbol": {
                             "value": "",
                             "type": "http://http://www.example.org/edr/metadata/lookup/mo_dp_uv"
@@ -351,7 +380,7 @@ There are also links to the license information for the observation and forecast
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/grib2/codeflag/4.2/_0-4-51",
-                        "label":  "UV index"
+                        "label": "UV index"
                     },
                     "measurementType": {
                         "method": "instantaneous",
@@ -362,7 +391,7 @@ There are also links to the license information for the observation and forecast
                     "type": "Parameter",
                     "description": "",
                     "unit": {
-                        "label":  "percent",
+                        "label": "percent",
                         "symbol": {
                             "value": "%",
                             "type": "http://http://www.example.org/edr/metadata/units/percent"
@@ -370,7 +399,7 @@ There are also links to the license information for the observation and forecast
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/grib2/codeflag/4.2/_0-1-1",
-                        "label":  "Probabilty of precipitation"
+                        "label": "Probabilty of precipitation"
                     },
                     "measurementType": {
                         "method": "instantaneous",
@@ -381,7 +410,7 @@ There are also links to the license information for the observation and forecast
                     "type": "Parameter",
                     "description": "",
                     "unit": {
-                        "label":  "quality",
+                        "label": "quality",
                         "symbol": {
                             "value": "",
                             "type": "http://http://www.example.org/edr/metadata/lookup/mo_dp_visibility"
@@ -389,7 +418,7 @@ There are also links to the license information for the observation and forecast
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/common/quantity-kind/_horizontalVisibility",
-                        "label":  "Visibility"
+                        "label": "Visibility"
                     },
                     "measurementType": {
                         "method": "instantaneous",
@@ -416,111 +445,24 @@ There are also links to the license information for the observation and forecast
             ],
             "links": [
                 {
-                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/position?coords={coords}",
+                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/position",
                     "hreflang": "en",
-                    "rel": "data",
-                    "templated": true,
-                    "variables": {
-                        "title": "Position query",
-                        "description": "Position query",
-                        "query_type": "position",
-                        "coords" :{
-                            "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
-                        },                        
-                        "output_formats": [
-                            "CoverageJSON",
-                            "GeoJSON"
-                        ],
-                        "default_output_format": "GeoJSON",
-                        "crs_details": [
-                            {
-                                "crs": "CRS84",
-                                "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
-                            }
-                        ]    
-                    }
-
+                    "rel": "data"
                 },
                 {
-                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/radius?coords={coords}",
+                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/radius",
                     "hreflang": "en",
-                    "rel": "data",
-                    "templated": true,
-                    "variables": {
-                        "title": "Radius query",
-                        "description": "Radius query",
-                        "query_type": "radius",
-                        "coords" :{
-                            "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
-                        },
-                        "output_formats": [
-                            "CoverageJSON",
-                            "GeoJSON",
-                            "CSV"
-                        ],
-                        "default_output_format": "GeoJSON",
-                        "within_units": [
-                            "km",
-                            "miles"
-                        ],
-                        "crs_details": [
-                            {
-                                "crs": "CRS84",
-                                "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
-                            }
-                        ]    
-                    }
-
+                    "rel": "data"
                 },
                 {
-                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/area?coords={coords}",
+                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/area",
                     "hreflang": "en",
-                    "rel": "data",
-                    "title": "",
-                    "templated": true,
-                    "variables": {
-                        "title": "Area query",
-                        "description": "Area query",
-                        "query_type": "area",
-                        "coords" :{
-                            "description": "Well Known Text POLYGON value i.e. POLYGON((-79 40,-79 38,-75 38,-75 41,-79 40))"
-                        },
-                        "output_formats": [
-                            "CoverageJSON",
-                            "GeoJSON",
-                            "CSV"
-                        ],
-                        "default_output_format": "CoverageJSON",
-                        "crs_details": [
-                            {
-                                "crs": "CRS84",
-                                "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
-                            }
-                        ]    
-                    }
-                    
+                    "rel": "data"
                 },
                 {
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/locations",
                     "hreflang": "en",
-                    "rel": "data",
-                    "templated": false,
-                    "variables": {
-                        "title": "Locations query",
-                        "description": "Locations query",
-                        "query_type": "location",
-                        "output_formats": [
-                            "CoverageJSON",
-                            "GeoJSON"
-                        ],
-                        "default_output_format": "GeoJSON",
-                        "crs_details": [
-                            {
-                                "crs": "CRS84",
-                                "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
-                            }
-                        ]    
-                    }
+                    "rel": "data"
                 }
             ],
             "extent": {
@@ -540,7 +482,123 @@ There are also links to the license information for the observation and forecast
                     "trs": "TIMECRS[\"DateTime\",TDATUM[\"Gregorian Calendar\"],CS[TemporalDateTime,1],AXIS[\"Time (T)\",future]"
                 }
             },
-            "crs": ["CRS84"],
+            "data_queries": {
+                "position": {
+                    "link": {
+                        "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/position?coords={coords}",
+                        "hreflang": "en",
+                        "rel": "data",
+                        "templated": true,
+                        "variables": {
+                            "title": "Position query",
+                            "description": "Position query",
+                            "query_type": "position",
+                            "coords": {
+                                "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
+                            },
+                            "output_formats": [
+                                "CoverageJSON",
+                                "GeoJSON"
+                            ],
+                            "default_output_format": "GeoJSON",
+                            "crs_details": [
+                                {
+                                    "crs": "CRS84",
+                                    "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "radius": {
+                    "link": {
+                        "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/radius?coords={coords}",
+                        "hreflang": "en",
+                        "rel": "data",
+                        "templated": true,
+                        "variables": {
+                            "title": "Radius query",
+                            "description": "Radius query",
+                            "query_type": "radius",
+                            "coords": {
+                                "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
+                            },
+                            "output_formats": [
+                                "CoverageJSON",
+                                "GeoJSON",
+                                "CSV"
+                            ],
+                            "default_output_format": "GeoJSON",
+                            "within_units": [
+                                "km",
+                                "miles"
+                            ],
+                            "crs_details": [
+                                {
+                                    "crs": "CRS84",
+                                    "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "area": {
+                    "link": {
+                        "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/area?coords={coords}",
+                        "hreflang": "en",
+                        "rel": "data",
+                        "title": "",
+                        "templated": true,
+                        "variables": {
+                            "title": "Area query",
+                            "description": "Area query",
+                            "query_type": "area",
+                            "coords": {
+                                "description": "Well Known Text POLYGON value i.e. POLYGON((-79 40,-79 38,-75 38,-75 41,-79 40))"
+                            },
+                            "output_formats": [
+                                "CoverageJSON",
+                                "GeoJSON",
+                                "CSV"
+                            ],
+                            "default_output_format": "CoverageJSON",
+                            "crs_details": [
+                                {
+                                    "crs": "CRS84",
+                                    "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "locations": {
+                    "link": {
+                        "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/locations",
+                        "hreflang": "en",
+                        "rel": "data",
+                        "templated": false,
+                        "variables": {
+                            "title": "Locations query",
+                            "description": "Locations query",
+                            "query_type": "location",
+                            "output_formats": [
+                                "CoverageJSON",
+                                "GeoJSON"
+                            ],
+                            "default_output_format": "GeoJSON",
+                            "crs_details": [
+                                {
+                                    "crs": "CRS84",
+                                    "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            "crs": [
+                "CRS84"
+            ],
             "output_formats": [
                 "GeoJSON",
                 "CoverageJSON",
@@ -559,7 +617,7 @@ There are also links to the license information for the observation and forecast
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/grib2/codeflag/4.2/_0-2-0",
-                        "label":  "Wind Direction"
+                        "label": "Wind Direction"
                     },
                     "measurementType": {
                         "method": "mean",
@@ -570,7 +628,7 @@ There are also links to the license information for the observation and forecast
                     "type": "Parameter",
                     "description": "Average wind speed",
                     "unit": {
-                        "label":  "mph",
+                        "label": "mph",
                         "symbol": {
                             "value": "mph",
                             "type": "http://http://www.example.org/edr/metadata/units/mph"
@@ -589,7 +647,7 @@ There are also links to the license information for the observation and forecast
                     "type": "Parameter",
                     "description": "Wind gusts are a rapid increase in strength of the wind relative to the wind speed.",
                     "unit": {
-                        "label":  "mph",
+                        "label": "mph",
                         "symbol": {
                             "value": "mph",
                             "type": "http://http://www.example.org/edr/metadata/units/mph"
@@ -627,7 +685,7 @@ There are also links to the license information for the observation and forecast
                     "type": "Parameter",
                     "description": "",
                     "unit": {
-                        "label":  "weather",
+                        "label": "weather",
                         "symbol": {
                             "value": "",
                             "type": "http://http://www.example.org/edr/metadata/lookup/mo_dp_weather"
@@ -646,7 +704,7 @@ There are also links to the license information for the observation and forecast
                     "type": "Parameter",
                     "description": "",
                     "unit": {
-                        "label":  "percent",
+                        "label": "percent",
                         "symbol": {
                             "value": "%",
                             "type": "http://http://www.example.org/edr/metadata/units/percent"
@@ -654,7 +712,7 @@ There are also links to the license information for the observation and forecast
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/grib2/codeflag/4.2/_0-1-1",
-                        "label":  "Relative Humidity"
+                        "label": "Relative Humidity"
                     },
                     "measurementType": {
                         "method": "instantaneous",
@@ -665,7 +723,7 @@ There are also links to the license information for the observation and forecast
                     "type": "Parameter",
                     "description": "",
                     "unit": {
-                        "label":  "degC",
+                        "label": "degC",
                         "symbol": {
                             "value": "°C",
                             "type": "http://http://www.example.org/edr/metadata/units/degC"
@@ -673,7 +731,7 @@ There are also links to the license information for the observation and forecast
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/common/quantity-kind/_airTemperature",
-                        "label":  "Feels like temperature"
+                        "label": "Feels like temperature"
                     },
                     "measurementType": {
                         "method": "instantaneous",
@@ -684,7 +742,7 @@ There are also links to the license information for the observation and forecast
                     "type": "Parameter",
                     "description": "",
                     "unit": {
-                        "label":  "UV_index",
+                        "label": "UV_index",
                         "symbol": {
                             "value": "",
                             "type": "http://http://www.example.org/edr/metadata/lookup/mo_dp_uv"
@@ -692,7 +750,7 @@ There are also links to the license information for the observation and forecast
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/grib2/codeflag/4.2/_0-4-51",
-                        "label":  "UV index"
+                        "label": "UV index"
                     },
                     "measurementType": {
                         "method": "instantaneous",
@@ -703,7 +761,7 @@ There are also links to the license information for the observation and forecast
                     "type": "Parameter",
                     "description": "",
                     "unit": {
-                        "label":  "percent",
+                        "label": "percent",
                         "symbol": {
                             "value": "%",
                             "type": "http://http://www.example.org/edr/metadata/units/percent"
@@ -711,7 +769,7 @@ There are also links to the license information for the observation and forecast
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/grib2/codeflag/4.2/_0-1-1",
-                        "label":  "Probabilty of precipitation"
+                        "label": "Probabilty of precipitation"
                     },
                     "measurementType": {
                         "method": "instantaneous",
@@ -722,7 +780,7 @@ There are also links to the license information for the observation and forecast
                     "type": "Parameter",
                     "description": "",
                     "unit": {
-                        "label":  "quality",
+                        "label": "quality",
                         "symbol": {
                             "value": "",
                             "type": "http://http://www.example.org/edr/metadata/lookup/mo_dp_visibility"
@@ -730,7 +788,7 @@ There are also links to the license information for the observation and forecast
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/common/quantity-kind/_horizontalVisibility",
-                        "label":  "Visibility"
+                        "label": "Visibility"
                     },
                     "measurementType": {
                         "method": "instantaneous",
@@ -757,110 +815,24 @@ There are also links to the license information for the observation and forecast
             ],
             "links": [
                 {
-                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/position?coords={coords}",
+                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/position",
                     "hreflang": "en",
-                    "rel": "data",
-                    "templated": true,
-                    "variables": {
-                        "title": "Position query",
-                        "description": "Position query",
-                        "query_type": "position",
-                        "coords" :{
-                            "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
-                        },
-                        "output_formats": [
-                            "CoverageJSON",
-                            "GeoJSON"
-                        ],
-                        "default_output_format": "GeoJSON",
-                        "crs_details": [
-                            {
-                                "crs": "CRS84",
-                                "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
-                            }
-                        ]    
-                    }
-
+                    "rel": "data"
                 },
                 {
-                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/radius?coords={coords}",
+                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/radius",
                     "hreflang": "en",
-                    "rel": "data",
-                    "templated": true,
-                    "variables": {
-                        "title": "Radius query",
-                        "description": "Radius query",
-                        "query_type": "radius",
-                        "coords" :{
-                            "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
-                        },
-                        "output_formats": [
-                            "CoverageJSON",
-                            "GeoJSON",
-                            "CSV"
-                        ],
-                        "default_output_format": "GeoJSON",
-                        "within_units": [
-                            "km",
-                            "miles"
-                        ],
-                        "crs_details": [
-                            {
-                                "crs": "CRS84",
-                                "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
-                            }
-                        ]    
-                    }
-
+                    "rel": "data"
                 },
                 {
-                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/area?coords={coords}",
+                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/area",
                     "hreflang": "en",
-                    "rel": "data",
-                    "templated": true,
-                    "variables": {
-                        "title": "Area query",
-                        "description": "Area query",
-                        "query_type": "area",
-                        "coords" :{
-                            "description": "Well Known Text POLYGON value i.e. POLYGON((-79 40,-79 38,-75 38,-75 41,-79 40))"
-                        },
-                        "output_formats": [
-                            "CoverageJSON",
-                            "GeoJSON",
-                            "CSV"
-                        ],
-                        "default_output_format": "CoverageJSON",
-                        "crs_details": [
-                            {
-                                "crs": "CRS84",
-                                "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
-                            }
-                        ]    
-                    }
-                    
+                    "rel": "data"
                 },
                 {
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/locations",
                     "hreflang": "en",
-                    "rel": "data",
-                    "templated": false,
-                    "variables": {
-                        "title": "Locations query",
-                        "description": "Locations query",
-                        "query_type": "location",
-                        "output_formats": [
-                            "CoverageJSON",
-                            "GeoJSON"
-                        ],
-                        "default_output_format": "GeoJSON",
-                        "crs_details": [
-                            {
-                                "crs": "CRS84",
-                                "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
-                            }
-                        ]    
-                    }
+                    "rel": "data"
                 }
             ],
             "extent": {
@@ -880,7 +852,123 @@ There are also links to the license information for the observation and forecast
                     "trs": "TIMECRS[\"DateTime\",TDATUM[\"Gregorian Calendar\"],CS[TemporalDateTime,1],AXIS[\"Time (T)\",future]"
                 }
             },
-            "crs": ["CRS84"],
+            "data_queries": {
+                "position": {
+                    "link": {
+                        "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/position?coords={coords}",
+                        "hreflang": "en",
+                        "rel": "data",
+                        "templated": true,
+                        "variables": {
+                            "title": "Position query",
+                            "description": "Position query",
+                            "query_type": "position",
+                            "coords": {
+                                "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
+                            },
+                            "output_formats": [
+                                "CoverageJSON",
+                                "GeoJSON"
+                            ],
+                            "default_output_format": "GeoJSON",
+                            "crs_details": [
+                                {
+                                    "crs": "CRS84",
+                                    "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "radius": {
+                    "link": {
+                        "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/radius?coords={coords}",
+                        "hreflang": "en",
+                        "rel": "data",
+                        "templated": true,
+                        "variables": {
+                            "title": "Radius query",
+                            "description": "Radius query",
+                            "query_type": "radius",
+                            "coords": {
+                                "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
+                            },
+                            "output_formats": [
+                                "CoverageJSON",
+                                "GeoJSON",
+                                "CSV"
+                            ],
+                            "default_output_format": "GeoJSON",
+                            "within_units": [
+                                "km",
+                                "miles"
+                            ],
+                            "crs_details": [
+                                {
+                                    "crs": "CRS84",
+                                    "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "area": {
+                    "link": {
+                        "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/area?coords={coords}",
+                        "hreflang": "en",
+                        "rel": "data",
+                        "title": "",
+                        "templated": true,
+                        "variables": {
+                            "title": "Area query",
+                            "description": "Area query",
+                            "query_type": "area",
+                            "coords": {
+                                "description": "Well Known Text POLYGON value i.e. POLYGON((-79 40,-79 38,-75 38,-75 41,-79 40))"
+                            },
+                            "output_formats": [
+                                "CoverageJSON",
+                                "GeoJSON",
+                                "CSV"
+                            ],
+                            "default_output_format": "CoverageJSON",
+                            "crs_details": [
+                                {
+                                    "crs": "CRS84",
+                                    "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "locations": {
+                    "link": {
+                        "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/locations",
+                        "hreflang": "en",
+                        "rel": "data",
+                        "templated": false,
+                        "variables": {
+                            "title": "Locations query",
+                            "description": "Locations query",
+                            "query_type": "location",
+                            "output_formats": [
+                                "CoverageJSON",
+                                "GeoJSON"
+                            ],
+                            "default_output_format": "GeoJSON",
+                            "crs_details": [
+                                {
+                                    "crs": "CRS84",
+                                    "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            "crs": [
+                "CRS84"
+            ],
             "output_formats": [
                 "GeoJSON",
                 "CoverageJSON",
@@ -899,7 +987,7 @@ There are also links to the license information for the observation and forecast
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/grib2/codeflag/4.2/_0-2-0",
-                        "label":  "Wind Direction"
+                        "label": "Wind Direction"
                     },
                     "measurementType": {
                         "method": "mean",
@@ -910,7 +998,7 @@ There are also links to the license information for the observation and forecast
                     "type": "Parameter",
                     "description": "Average wind speed",
                     "unit": {
-                        "label":  "mph",
+                        "label": "mph",
                         "symbol": {
                             "value": "mph",
                             "type": "http://http://www.example.org/edr/metadata/units/mph"
@@ -929,7 +1017,7 @@ There are also links to the license information for the observation and forecast
                     "type": "Parameter",
                     "description": "Wind gusts are a rapid increase in strength of the wind relative to the wind speed.",
                     "unit": {
-                        "label":  "mph",
+                        "label": "mph",
                         "symbol": {
                             "value": "mph",
                             "type": "http://http://www.example.org/edr/metadata/units/mph"
@@ -967,7 +1055,7 @@ There are also links to the license information for the observation and forecast
                     "type": "Parameter",
                     "description": "",
                     "unit": {
-                        "label":  "weather",
+                        "label": "weather",
                         "symbol": {
                             "value": "",
                             "type": "http://http://www.example.org/edr/metadata/lookup/mo_dp_weather"
@@ -986,7 +1074,7 @@ There are also links to the license information for the observation and forecast
                     "type": "Parameter",
                     "description": "",
                     "unit": {
-                        "label":  "percent",
+                        "label": "percent",
                         "symbol": {
                             "value": "%",
                             "type": "http://http://www.example.org/edr/metadata/units/percent"
@@ -994,7 +1082,7 @@ There are also links to the license information for the observation and forecast
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/grib2/codeflag/4.2/_0-1-1",
-                        "label":  "Relative Humidity"
+                        "label": "Relative Humidity"
                     },
                     "measurementType": {
                         "method": "instantaneous",
@@ -1005,7 +1093,7 @@ There are also links to the license information for the observation and forecast
                     "type": "Parameter",
                     "description": "",
                     "unit": {
-                        "label":  "degC",
+                        "label": "degC",
                         "symbol": {
                             "value": "°C",
                             "type": "http://http://www.example.org/edr/metadata/units/degC"
@@ -1013,7 +1101,7 @@ There are also links to the license information for the observation and forecast
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/common/quantity-kind/_airTemperature",
-                        "label":  "Feels like temperature"
+                        "label": "Feels like temperature"
                     },
                     "measurementType": {
                         "method": "instantaneous",
@@ -1024,7 +1112,7 @@ There are also links to the license information for the observation and forecast
                     "type": "Parameter",
                     "description": "",
                     "unit": {
-                        "label":  "UV_index",
+                        "label": "UV_index",
                         "symbol": {
                             "value": "",
                             "type": "http://http://www.example.org/edr/metadata/lookup/mo_dp_uv"
@@ -1032,7 +1120,7 @@ There are also links to the license information for the observation and forecast
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/grib2/codeflag/4.2/_0-4-51",
-                        "label":  "UV index"
+                        "label": "UV index"
                     },
                     "measurementType": {
                         "method": "instantaneous",
@@ -1043,7 +1131,7 @@ There are also links to the license information for the observation and forecast
                     "type": "Parameter",
                     "description": "",
                     "unit": {
-                        "label":  "percent",
+                        "label": "percent",
                         "symbol": {
                             "value": "%",
                             "type": "http://http://www.example.org/edr/metadata/units/percent"
@@ -1051,7 +1139,7 @@ There are also links to the license information for the observation and forecast
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/grib2/codeflag/4.2/_0-1-1",
-                        "label":  "Probabilty of precipitation"
+                        "label": "Probabilty of precipitation"
                     },
                     "measurementType": {
                         "method": "instantaneous",
@@ -1062,7 +1150,7 @@ There are also links to the license information for the observation and forecast
                     "type": "Parameter",
                     "description": "",
                     "unit": {
-                        "label":  "quality",
+                        "label": "quality",
                         "symbol": {
                             "value": "",
                             "type": "http://http://www.example.org/edr/metadata/lookup/mo_dp_visibility"
@@ -1070,7 +1158,7 @@ There are also links to the license information for the observation and forecast
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/common/quantity-kind/_horizontalVisibility",
-                        "label":  "Visibility"
+                        "label": "Visibility"
                     },
                     "measurementType": {
                         "method": "instantaneous",
@@ -1097,110 +1185,24 @@ There are also links to the license information for the observation and forecast
             ],
             "links": [
                 {
-                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/position?coords={coords}",
+                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/position",
                     "hreflang": "en",
-                    "rel": "data",
-                    "templated": true,
-                    "variables": {
-                        "title": "Position query",
-                        "description": "Position query",
-                        "query_type": "position",
-                        "coords" :{
-                            "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
-                        },
-                        "output_formats": [
-                            "CoverageJSON",
-                            "GeoJSON"
-                        ],
-                        "default_output_format": "GeoJSON",
-                        "crs_details": [
-                            {
-                                "crs": "CRS84",
-                                "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
-                            }
-                        ]    
-                    }
-
+                    "rel": "data"
                 },
                 {
-                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/radius?coords={coords}",
+                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/radius",
                     "hreflang": "en",
-                    "rel": "data",
-                    "templated": true,
-                    "variables": {
-                        "title": "Radius query",
-                        "description": "Radius query",
-                        "query_type": "radius",
-                        "coords" :{
-                            "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
-                        },
-                        "output_formats": [
-                            "CoverageJSON",
-                            "GeoJSON",
-                            "CSV"
-                        ],
-                        "default_output_format": "GeoJSON",
-                        "within_units": [
-                            "km",
-                            "miles"
-                        ],
-                        "crs_details": [
-                            {
-                                "crs": "CRS84",
-                                "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
-                            }
-                        ]    
-                    }
-
+                    "rel": "data"
                 },
                 {
-                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/area?coords={coords}",
+                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/area",
                     "hreflang": "en",
-                    "rel": "data",
-                    "templated": true,
-                    "variables": {
-                        "title": "Area query",
-                        "description": "Area query",
-                        "query_type": "area",
-                        "coords" :{
-                            "description": "Well Known Text POLYGON value i.e. POLYGON((-79 40,-79 38,-75 38,-75 41,-79 40))"
-                        },
-                        "output_formats": [
-                            "CoverageJSON",
-                            "GeoJSON",
-                            "CSV"
-                        ],
-                        "default_output_format": "CoverageJSON",
-                        "crs_details": [
-                            {
-                                "crs": "CRS84",
-                                "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
-                            }
-                        ]    
-                    }
-                    
+                    "rel": "data"
                 },
                 {
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/locations",
                     "hreflang": "en",
-                    "rel": "data",
-                    "templated": false,
-                    "variables": {
-                        "title": "Locations query",
-                        "description": "Locations query",
-                        "query_type": "location",
-                        "output_formats": [
-                            "CoverageJSON",
-                            "GeoJSON"
-                        ],
-                        "default_output_format": "GeoJSON",
-                        "crs_details": [
-                            {
-                                "crs": "CRS84",
-                                "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
-                            }
-                        ]    
-                    }
+                    "rel": "data"
                 }
             ],
             "extent": {
@@ -1220,7 +1222,122 @@ There are also links to the license information for the observation and forecast
                     "trs": "TIMECRS[\"DateTime\",TDATUM[\"Gregorian Calendar\"],CS[TemporalDateTime,1],AXIS[\"Time (T)\",future]"
                 }
             },
-            "crs": ["CRS84"],
+            "data_queries": {
+                "position": {
+                    "link": {
+                        "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/position?coords={coords}",
+                        "hreflang": "en",
+                        "rel": "data",
+                        "templated": true,
+                        "variables": {
+                            "title": "Position query",
+                            "description": "Position query",
+                            "query_type": "position",
+                            "coords": {
+                                "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
+                            },
+                            "output_formats": [
+                                "CoverageJSON",
+                                "GeoJSON"
+                            ],
+                            "default_output_format": "GeoJSON",
+                            "crs_details": [
+                                {
+                                    "crs": "CRS84",
+                                    "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "radius": {
+                    "link": {
+                        "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/radius?coords={coords}",
+                        "hreflang": "en",
+                        "rel": "data",
+                        "templated": true,
+                        "variables": {
+                            "title": "Radius query",
+                            "description": "Radius query",
+                            "query_type": "radius",
+                            "coords": {
+                                "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
+                            },
+                            "output_formats": [
+                                "CoverageJSON",
+                                "GeoJSON",
+                                "CSV"
+                            ],
+                            "default_output_format": "GeoJSON",
+                            "within_units": [
+                                "km",
+                                "miles"
+                            ],
+                            "crs_details": [
+                                {
+                                    "crs": "CRS84",
+                                    "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "area": {
+                    "link": {
+                        "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/area?coords={coords}",
+                        "hreflang": "en",
+                        "rel": "data",
+                        "templated": true,
+                        "variables": {
+                            "title": "Area query",
+                            "description": "Area query",
+                            "query_type": "area",
+                            "coords": {
+                                "description": "Well Known Text POLYGON value i.e. POLYGON((-79 40,-79 38,-75 38,-75 41,-79 40))"
+                            },
+                            "output_formats": [
+                                "CoverageJSON",
+                                "GeoJSON",
+                                "CSV"
+                            ],
+                            "default_output_format": "CoverageJSON",
+                            "crs_details": [
+                                {
+                                    "crs": "CRS84",
+                                    "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "locations": {
+                    "link": {
+                        "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/locations",
+                        "hreflang": "en",
+                        "rel": "data",
+                        "templated": false,
+                        "variables": {
+                            "title": "Locations query",
+                            "description": "Locations query",
+                            "query_type": "location",
+                            "output_formats": [
+                                "CoverageJSON",
+                                "GeoJSON"
+                            ],
+                            "default_output_format": "GeoJSON",
+                            "crs_details": [
+                                {
+                                    "crs": "CRS84",
+                                    "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            "crs": [
+                "CRS84"
+            ],
             "output_formats": [
                 "GeoJSON",
                 "CoverageJSON",
@@ -1239,7 +1356,7 @@ There are also links to the license information for the observation and forecast
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/grib2/codeflag/4.2/_0-2-0",
-                        "label":  "Wind Direction"
+                        "label": "Wind Direction"
                     },
                     "measurementType": {
                         "method": "mean",
@@ -1250,7 +1367,7 @@ There are also links to the license information for the observation and forecast
                     "type": "Parameter",
                     "description": "Average wind speed",
                     "unit": {
-                        "label":  "mph",
+                        "label": "mph",
                         "symbol": {
                             "value": "mph",
                             "type": "http://http://www.example.org/edr/metadata/units/mph"
@@ -1269,7 +1386,7 @@ There are also links to the license information for the observation and forecast
                     "type": "Parameter",
                     "description": "Wind gusts are a rapid increase in strength of the wind relative to the wind speed.",
                     "unit": {
-                        "label":  "mph",
+                        "label": "mph",
                         "symbol": {
                             "value": "mph",
                             "type": "http://http://www.example.org/edr/metadata/units/mph"
@@ -1307,7 +1424,7 @@ There are also links to the license information for the observation and forecast
                     "type": "Parameter",
                     "description": "",
                     "unit": {
-                        "label":  "weather",
+                        "label": "weather",
                         "symbol": {
                             "value": "",
                             "type": "http://http://www.example.org/edr/metadata/lookup/mo_dp_weather"
@@ -1326,7 +1443,7 @@ There are also links to the license information for the observation and forecast
                     "type": "Parameter",
                     "description": "",
                     "unit": {
-                        "label":  "percent",
+                        "label": "percent",
                         "symbol": {
                             "value": "%",
                             "type": "http://http://www.example.org/edr/metadata/units/percent"
@@ -1334,7 +1451,7 @@ There are also links to the license information for the observation and forecast
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/grib2/codeflag/4.2/_0-1-1",
-                        "label":  "Relative Humidity"
+                        "label": "Relative Humidity"
                     },
                     "measurementType": {
                         "method": "instantaneous",
@@ -1345,7 +1462,7 @@ There are also links to the license information for the observation and forecast
                     "type": "Parameter",
                     "description": "",
                     "unit": {
-                        "label":  "degC",
+                        "label": "degC",
                         "symbol": {
                             "value": "°C",
                             "type": "http://http://www.example.org/edr/metadata/units/degC"
@@ -1353,7 +1470,7 @@ There are also links to the license information for the observation and forecast
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/common/quantity-kind/_airTemperature",
-                        "label":  "Feels like temperature"
+                        "label": "Feels like temperature"
                     },
                     "measurementType": {
                         "method": "instantaneous",
@@ -1364,7 +1481,7 @@ There are also links to the license information for the observation and forecast
                     "type": "Parameter",
                     "description": "",
                     "unit": {
-                        "label":  "UV_index",
+                        "label": "UV_index",
                         "symbol": {
                             "value": "",
                             "type": "http://http://www.example.org/edr/metadata/lookup/mo_dp_uv"
@@ -1372,7 +1489,7 @@ There are also links to the license information for the observation and forecast
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/grib2/codeflag/4.2/_0-4-51",
-                        "label":  "UV index"
+                        "label": "UV index"
                     },
                     "measurementType": {
                         "method": "instantaneous",
@@ -1383,7 +1500,7 @@ There are also links to the license information for the observation and forecast
                     "type": "Parameter",
                     "description": "",
                     "unit": {
-                        "label":  "percent",
+                        "label": "percent",
                         "symbol": {
                             "value": "%",
                             "type": "http://http://www.example.org/edr/metadata/units/percent"
@@ -1391,7 +1508,7 @@ There are also links to the license information for the observation and forecast
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/grib2/codeflag/4.2/_0-1-1",
-                        "label":  "Probabilty of precipitation"
+                        "label": "Probabilty of precipitation"
                     },
                     "measurementType": {
                         "method": "instantaneous",
@@ -1402,7 +1519,7 @@ There are also links to the license information for the observation and forecast
                     "type": "Parameter",
                     "description": "",
                     "unit": {
-                        "label":  "quality",
+                        "label": "quality",
                         "symbol": {
                             "value": "",
                             "type": "http://http://www.example.org/edr/metadata/lookup/mo_dp_visibility"
@@ -1410,7 +1527,7 @@ There are also links to the license information for the observation and forecast
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/common/quantity-kind/_horizontalVisibility",
-                        "label":  "Visibility"
+                        "label": "Visibility"
                     },
                     "measurementType": {
                         "method": "instantaneous",
@@ -1418,7 +1535,6 @@ There are also links to the license information for the observation and forecast
                     }
                 }
             }
-
         }
     ]
 }

--- a/candidate-standard/examples/instance_metadata_JSON.adoc
+++ b/candidate-standard/examples/instance_metadata_JSON.adoc
@@ -82,6 +82,7 @@ There are also links to the license information for the observation and forecast
                     "variables": {
                         "title": "Position query",
                         "description": "Position query",
+                        "query_type": "position",
                         "output_formats": [
                             "CoverageJSON",
                             "GeoJSON"
@@ -104,6 +105,7 @@ There are also links to the license information for the observation and forecast
                     "variables": {
                         "title": "Radius query",
                         "description": "Radius query",
+                        "query_type": "radius",
                         "output_formats": [
                             "CoverageJSON",
                             "GeoJSON",
@@ -131,6 +133,7 @@ There are also links to the license information for the observation and forecast
                     "variables": {
                         "title": "Area query",
                         "description": "Area query",
+                        "query_type": "area",
                         "output_formats": [
                             "CoverageJSON",
                             "GeoJSON",
@@ -394,6 +397,7 @@ There are also links to the license information for the observation and forecast
                     "variables": {
                         "title": "Position query",
                         "description": "Position query",
+                        "query_type": "position",
                         "output_formats": [
                             "CoverageJSON",
                             "GeoJSON"
@@ -416,6 +420,7 @@ There are also links to the license information for the observation and forecast
                     "variables": {
                         "title": "Radius query",
                         "description": "Radius query",
+                        "query_type": "radius",
                         "output_formats": [
                             "CoverageJSON",
                             "GeoJSON",
@@ -443,6 +448,7 @@ There are also links to the license information for the observation and forecast
                     "variables": {
                         "title": "Area query",
                         "description": "Area query",
+                        "query_type": "area",
                         "output_formats": [
                             "CoverageJSON",
                             "GeoJSON",
@@ -706,6 +712,7 @@ There are also links to the license information for the observation and forecast
                     "variables": {
                         "title": "Position query",
                         "description": "Position query",
+                        "query_type": "position",
                         "output_formats": [
                             "CoverageJSON",
                             "GeoJSON"
@@ -728,6 +735,7 @@ There are also links to the license information for the observation and forecast
                     "variables": {
                         "title": "Radius query",
                         "description": "Radius query",
+                        "query_type": "radius",
                         "output_formats": [
                             "CoverageJSON",
                             "GeoJSON",
@@ -755,6 +763,7 @@ There are also links to the license information for the observation and forecast
                     "variables": {
                         "title": "Area query",
                         "description": "Area query",
+                        "query_type": "area",
                         "output_formats": [
                             "CoverageJSON",
                             "GeoJSON",
@@ -1018,6 +1027,7 @@ There are also links to the license information for the observation and forecast
                     "variables": {
                         "title": "Position query",
                         "description": "Position query",
+                        "query_type": "position",
                         "output_formats": [
                             "CoverageJSON",
                             "GeoJSON"
@@ -1040,6 +1050,7 @@ There are also links to the license information for the observation and forecast
                     "variables": {
                         "title": "Radius query",
                         "description": "Radius query",
+                        "query_type": "radius",
                         "output_formats": [
                             "CoverageJSON",
                             "GeoJSON",
@@ -1067,6 +1078,7 @@ There are also links to the license information for the observation and forecast
                     "variables": {
                         "title": "Area query",
                         "description": "Area query",
+                        "query_type": "area",
                         "output_formats": [
                             "CoverageJSON",
                             "GeoJSON",

--- a/candidate-standard/examples/instance_metadata_JSON.adoc
+++ b/candidate-standard/examples/instance_metadata_JSON.adoc
@@ -78,7 +78,6 @@ There are also links to the license information for the observation and forecast
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/position",
                     "hreflang": "en",
                     "rel": "data",
-                    "type": "position",
                     "title": "",
                     "variables": {
                         "title": "Position query",
@@ -101,7 +100,6 @@ There are also links to the license information for the observation and forecast
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/radius",
                     "hreflang": "en",
                     "rel": "data",
-                    "type": "radius",
                     "title": "",
                     "variables": {
                         "title": "Radius query",
@@ -129,7 +127,6 @@ There are also links to the license information for the observation and forecast
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/area",
                     "hreflang": "en",
                     "rel": "data",
-                    "type": "area",
                     "title": "",
                     "variables": {
                         "title": "Area query",
@@ -153,7 +150,6 @@ There are also links to the license information for the observation and forecast
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/locations",
                     "hreflang": "en",
                     "rel": "data",
-                    "type": "location",
                     "title": ""
                 }
             ],
@@ -394,7 +390,6 @@ There are also links to the license information for the observation and forecast
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/position",
                     "hreflang": "en",
                     "rel": "data",
-                    "type": "position",
                     "title": "",
                     "variables": {
                         "title": "Position query",
@@ -417,7 +412,6 @@ There are also links to the license information for the observation and forecast
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/radius",
                     "hreflang": "en",
                     "rel": "data",
-                    "type": "radius",
                     "title": "",
                     "variables": {
                         "title": "Radius query",
@@ -445,7 +439,6 @@ There are also links to the license information for the observation and forecast
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/area",
                     "hreflang": "en",
                     "rel": "data",
-                    "type": "area",
                     "title": "",
                     "variables": {
                         "title": "Area query",
@@ -469,7 +462,6 @@ There are also links to the license information for the observation and forecast
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/locations",
                     "hreflang": "en",
                     "rel": "data",
-                    "type": "location",
                     "title": ""
                 }
             ],
@@ -710,7 +702,6 @@ There are also links to the license information for the observation and forecast
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/position",
                     "hreflang": "en",
                     "rel": "data",
-                    "type": "position",
                     "title": "",
                     "variables": {
                         "title": "Position query",
@@ -733,7 +724,6 @@ There are also links to the license information for the observation and forecast
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/radius",
                     "hreflang": "en",
                     "rel": "data",
-                    "type": "radius",
                     "title": "",
                     "variables": {
                         "title": "Radius query",
@@ -761,7 +751,6 @@ There are also links to the license information for the observation and forecast
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/area",
                     "hreflang": "en",
                     "rel": "data",
-                    "type": "area",
                     "title": "",
                     "variables": {
                         "title": "Area query",
@@ -785,7 +774,6 @@ There are also links to the license information for the observation and forecast
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/locations",
                     "hreflang": "en",
                     "rel": "data",
-                    "type": "location",
                     "title": ""
                 }
             ],
@@ -1026,7 +1014,6 @@ There are also links to the license information for the observation and forecast
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/position",
                     "hreflang": "en",
                     "rel": "data",
-                    "type": "position",
                     "title": "",
                     "variables": {
                         "title": "Position query",
@@ -1049,7 +1036,6 @@ There are also links to the license information for the observation and forecast
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/radius",
                     "hreflang": "en",
                     "rel": "data",
-                    "type": "radius",
                     "title": "",
                     "variables": {
                         "title": "Radius query",
@@ -1077,7 +1063,6 @@ There are also links to the license information for the observation and forecast
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/area",
                     "hreflang": "en",
                     "rel": "data",
-                    "type": "area",
                     "title": "",
                     "variables": {
                         "title": "Area query",
@@ -1101,7 +1086,6 @@ There are also links to the license information for the observation and forecast
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/locations",
                     "hreflang": "en",
                     "rel": "data",
-                    "type": "location",
                     "title": ""
                 }
             ],

--- a/candidate-standard/examples/instance_metadata_JSON.adoc
+++ b/candidate-standard/examples/instance_metadata_JSON.adoc
@@ -75,7 +75,7 @@ There are also links to the license information for the observation and forecast
             ],
             "links": [
                 {
-                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/position",
+                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/position?coords={coords}",
                     "hreflang": "en",
                     "rel": "data",
                     "title": "",
@@ -83,6 +83,10 @@ There are also links to the license information for the observation and forecast
                         "title": "Position query",
                         "description": "Position query",
                         "query_type": "position",
+                        "templated": true,
+                        "coords" :{
+                            "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
+                        },                        
                         "output_formats": [
                             "CoverageJSON",
                             "GeoJSON"
@@ -98,14 +102,17 @@ There are also links to the license information for the observation and forecast
 
                 },
                 {
-                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/radius",
+                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/radius?coords={coords}",
                     "hreflang": "en",
                     "rel": "data",
-                    "title": "",
                     "variables": {
                         "title": "Radius query",
                         "description": "Radius query",
                         "query_type": "radius",
+                        "templated": true,
+                        "coords" :{
+                            "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
+                        },                        
                         "output_formats": [
                             "CoverageJSON",
                             "GeoJSON",
@@ -126,14 +133,17 @@ There are also links to the license information for the observation and forecast
 
                 },
                 {
-                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/area",
+                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/area?coords={coords}",
                     "hreflang": "en",
                     "rel": "data",
-                    "title": "",
                     "variables": {
                         "title": "Area query",
                         "description": "Area query",
                         "query_type": "area",
+                        "templated": true,
+                        "coords" :{
+                            "description": "Well Known Text POLYGON value i.e. POLYGON((-79 40,-79 38,-75 38,-75 41,-79 40))"
+                        },
                         "output_formats": [
                             "CoverageJSON",
                             "GeoJSON",
@@ -153,7 +163,23 @@ There are also links to the license information for the observation and forecast
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/locations",
                     "hreflang": "en",
                     "rel": "data",
-                    "title": ""
+                    "variables": {
+                        "title": "Locations query",
+                        "description": "Locations query",
+                        "query_type": "location",
+                        "templated": false,
+                        "output_formats": [
+                            "CoverageJSON",
+                            "GeoJSON"
+                        ],
+                        "default_output_format": "GeoJSON",
+                        "crs_details": [
+                            {
+                                "crs": "CRS84",
+                                "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
+                            }
+                        ]    
+                    }
                 }
             ],
             "extent": {
@@ -390,14 +416,17 @@ There are also links to the license information for the observation and forecast
             ],
             "links": [
                 {
-                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/position",
+                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/position?coords={coords}",
                     "hreflang": "en",
                     "rel": "data",
-                    "title": "",
                     "variables": {
                         "title": "Position query",
                         "description": "Position query",
                         "query_type": "position",
+                        "templated": true,
+                        "coords" :{
+                            "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
+                        },                        
                         "output_formats": [
                             "CoverageJSON",
                             "GeoJSON"
@@ -413,7 +442,7 @@ There are also links to the license information for the observation and forecast
 
                 },
                 {
-                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/radius",
+                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/radius?coords={coords}",
                     "hreflang": "en",
                     "rel": "data",
                     "title": "",
@@ -421,6 +450,10 @@ There are also links to the license information for the observation and forecast
                         "title": "Radius query",
                         "description": "Radius query",
                         "query_type": "radius",
+                        "templated": true,
+                        "coords" :{
+                            "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
+                        },
                         "output_formats": [
                             "CoverageJSON",
                             "GeoJSON",
@@ -441,7 +474,7 @@ There are also links to the license information for the observation and forecast
 
                 },
                 {
-                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/area",
+                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/area?coords={coords}",
                     "hreflang": "en",
                     "rel": "data",
                     "title": "",
@@ -449,6 +482,10 @@ There are also links to the license information for the observation and forecast
                         "title": "Area query",
                         "description": "Area query",
                         "query_type": "area",
+                        "templated": true,
+                        "coords" :{
+                            "description": "Well Known Text POLYGON value i.e. POLYGON((-79 40,-79 38,-75 38,-75 41,-79 40))"
+                        },
                         "output_formats": [
                             "CoverageJSON",
                             "GeoJSON",
@@ -468,7 +505,23 @@ There are also links to the license information for the observation and forecast
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/locations",
                     "hreflang": "en",
                     "rel": "data",
-                    "title": ""
+                    "variables": {
+                        "title": "Locations query",
+                        "description": "Locations query",
+                        "query_type": "location",
+                        "templated": false,
+                        "output_formats": [
+                            "CoverageJSON",
+                            "GeoJSON"
+                        ],
+                        "default_output_format": "GeoJSON",
+                        "crs_details": [
+                            {
+                                "crs": "CRS84",
+                                "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
+                            }
+                        ]    
+                    }
                 }
             ],
             "extent": {
@@ -705,14 +758,17 @@ There are also links to the license information for the observation and forecast
             ],
             "links": [
                 {
-                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/position",
+                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/position?coords={coords}",
                     "hreflang": "en",
                     "rel": "data",
-                    "title": "",
                     "variables": {
                         "title": "Position query",
                         "description": "Position query",
                         "query_type": "position",
+                        "templated": true,
+                        "coords" :{
+                            "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
+                        },
                         "output_formats": [
                             "CoverageJSON",
                             "GeoJSON"
@@ -728,14 +784,17 @@ There are also links to the license information for the observation and forecast
 
                 },
                 {
-                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/radius",
+                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/radius?coords={coords}",
                     "hreflang": "en",
                     "rel": "data",
-                    "title": "",
                     "variables": {
                         "title": "Radius query",
                         "description": "Radius query",
                         "query_type": "radius",
+                        "templated": true,
+                        "coords" :{
+                            "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
+                        },
                         "output_formats": [
                             "CoverageJSON",
                             "GeoJSON",
@@ -756,14 +815,17 @@ There are also links to the license information for the observation and forecast
 
                 },
                 {
-                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/area",
+                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/area?coords={coords}",
                     "hreflang": "en",
                     "rel": "data",
-                    "title": "",
                     "variables": {
                         "title": "Area query",
                         "description": "Area query",
                         "query_type": "area",
+                        "templated": true,
+                        "coords" :{
+                            "description": "Well Known Text POLYGON value i.e. POLYGON((-79 40,-79 38,-75 38,-75 41,-79 40))"
+                        },
                         "output_formats": [
                             "CoverageJSON",
                             "GeoJSON",
@@ -783,7 +845,23 @@ There are also links to the license information for the observation and forecast
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/locations",
                     "hreflang": "en",
                     "rel": "data",
-                    "title": ""
+                    "variables": {
+                        "title": "Locations query",
+                        "description": "Locations query",
+                        "query_type": "location",
+                        "templated": false,
+                        "output_formats": [
+                            "CoverageJSON",
+                            "GeoJSON"
+                        ],
+                        "default_output_format": "GeoJSON",
+                        "crs_details": [
+                            {
+                                "crs": "CRS84",
+                                "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
+                            }
+                        ]    
+                    }
                 }
             ],
             "extent": {
@@ -1020,14 +1098,17 @@ There are also links to the license information for the observation and forecast
             ],
             "links": [
                 {
-                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/position",
+                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/position?coords={coords}",
                     "hreflang": "en",
                     "rel": "data",
-                    "title": "",
                     "variables": {
                         "title": "Position query",
                         "description": "Position query",
                         "query_type": "position",
+                        "templated": true,
+                        "coords" :{
+                            "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
+                        },
                         "output_formats": [
                             "CoverageJSON",
                             "GeoJSON"
@@ -1043,7 +1124,7 @@ There are also links to the license information for the observation and forecast
 
                 },
                 {
-                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/radius",
+                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/radius?coords={coords}",
                     "hreflang": "en",
                     "rel": "data",
                     "title": "",
@@ -1051,6 +1132,10 @@ There are also links to the license information for the observation and forecast
                         "title": "Radius query",
                         "description": "Radius query",
                         "query_type": "radius",
+                        "templated": true,
+                        "coords" :{
+                            "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
+                        },
                         "output_formats": [
                             "CoverageJSON",
                             "GeoJSON",
@@ -1071,14 +1156,17 @@ There are also links to the license information for the observation and forecast
 
                 },
                 {
-                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/area",
+                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/area?coords={coords}",
                     "hreflang": "en",
                     "rel": "data",
-                    "title": "",
                     "variables": {
                         "title": "Area query",
                         "description": "Area query",
                         "query_type": "area",
+                        "templated": true,
+                        "coords" :{
+                            "description": "Well Known Text POLYGON value i.e. POLYGON((-79 40,-79 38,-75 38,-75 41,-79 40))"
+                        },
                         "output_formats": [
                             "CoverageJSON",
                             "GeoJSON",
@@ -1098,7 +1186,23 @@ There are also links to the license information for the observation and forecast
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/locations",
                     "hreflang": "en",
                     "rel": "data",
-                    "title": ""
+                    "variables": {
+                        "title": "Locations query",
+                        "description": "Locations query",
+                        "query_type": "location",
+                        "templated": false,
+                        "output_formats": [
+                            "CoverageJSON",
+                            "GeoJSON"
+                        ],
+                        "default_output_format": "GeoJSON",
+                        "crs_details": [
+                            {
+                                "crs": "CRS84",
+                                "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
+                            }
+                        ]    
+                    }
                 }
             ],
             "extent": {

--- a/candidate-standard/openapi/examples/collection.json
+++ b/candidate-standard/openapi/examples/collection.json
@@ -1,17 +1,3 @@
-.Collections metadata response document
-=================
-The example below shows a service with two <<collection-definition,collections>>, one for observations and another for forecast data.  The forecast data is regenerated every hour so the <<collection-definition,collection>> provides access to multiple instances of the <<collection-definition,collection>> via an instances endpoint.
-
-There are links to the responses of the <<collection-definition,collections>> (link:https://www.iana.org/assignments/link-relations/link-relations.xhtml[link relation type]: "self"). 
-
-Representations of these resource in other formats are referenced using link:https://www.iana.org/assignments/link-relations/link-relations.xhtml[link relation type] "alternate".
-
-The data queries that are supported by each <<collection-definition,collection>> are referenced using link:https://www.iana.org/assignments/link-relations/link-relations.xhtml[link relation type] "data".
-
-There are also links to the license information for the observation and forecast data (using:https://www.iana.org/assignments/link-relations/link-relations.xhtml[link relation type] "license") and also the terms and conditions of service (using:https://www.iana.org/assignments/link-relations/link-relations.xhtml[link relation type] "restrictions") .
-
-[source,json]
-----
 {
     "links": [
         {
@@ -810,5 +796,3 @@ There are also links to the license information for the observation and forecast
         }
     ]
 }    
-----
-=================

--- a/candidate-standard/openapi/examples/collection.json
+++ b/candidate-standard/openapi/examples/collection.json
@@ -63,21 +63,74 @@
                     "hreflang": "en",
                     "rel": "data",
                     "type": "position",
-                    "title": ""
+                    "title": "",
+                    "variables": {
+                        "title": "Position query",
+                        "description": "Position query",
+                        "output_formats": [
+                            "CoverageJSON",
+                            "GeoJSON",
+                            "IWXXM"
+                        ],
+                        "default_output_format": "IWXXM",
+                        "crs_details": [
+                            {
+                                "crs": "CRS84",
+                                "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
+                            }
+                        ]    
+                    }
                 },
                 {
                     "href": "http://www.example.org/edr/collections/hrly_obs/radius",
                     "hreflang": "en",
                     "rel": "data",
                     "type": "radius",
-                    "title": ""
+                    "title": "",
+                    "variables": {
+                        "title": "Radius query",
+                        "description": "Radius query",
+                        "output_formats": [
+                            "CoverageJSON",
+                            "GeoJSON",
+                            "IWXXM"
+                        ],
+                        "default_output_format": "GeoJSON",
+                        "width_units": [
+                            "km",
+                            "miles"
+                        ],
+                        "crs_details": [
+                            {
+                                "crs": "CRS84",
+                                "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
+                            }
+                        ]    
+                    }
                 },
                 {
                     "href": "http://www.example.org/edr/collections/hrly_obs/area",
                     "hreflang": "en",
                     "rel": "data",
                     "type": "area",
-                    "title": ""
+                    "title": "",
+                    "variables": {
+                        "title": "Area query",
+                        "description": "Area query",
+                        "output_formats": [
+                            "CoverageJSON",
+                            "GeoJSON",
+                            "BUFR",
+                            "IWXXM"
+                        ],
+                        "default_output_format": "CoverageJSON",
+                        "crs_details": [
+                            {
+                                "crs": "CRS84",
+                                "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
+                            }
+                        ]    
+                    }
                 },
                 {
                     "href": "http://www.example.org/edr/collections/hrly_obs/locations",
@@ -107,67 +160,12 @@
             "crs": [
                 "CRS84"
             ],
-            "data-queries": {
-                "position": {
-                    "title": "Position query",
-                    "description": "Position query",
-                    "output-formats": [
-                        "CoverageJSON",
-                        "GeoJSON",
-                        "IWXXM"
-                    ],
-                    "default-output-format": "IWXXM",
-                    "crs-details": [
-                        {
-                            "crs": "CRS84",
-                            "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
-                        }
-                    ]
-                },
-                "radius": {
-                    "title": "Radius query",
-                    "description": "Radius query",
-                    "output-formats": [
-                        "CoverageJSON",
-                        "GeoJSON",
-                        "IWXXM"
-                    ],
-                    "default-output-format": "GeoJSON",
-                    "width-units": [
-                        "km",
-                        "miles"
-                    ],
-                    "crs-details": [
-                        {
-                            "crs": "CRS84",
-                            "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
-                        }
-                    ]
-                },
-                "area": {
-                    "title": "Area query",
-                    "description": "Area query",
-                    "output-formats": [
-                        "CoverageJSON",
-                        "GeoJSON",
-                        "BUFR",
-                        "IWXXM"
-                    ],
-                    "default-output-format": "CoverageJSON",
-                    "crs-details": [
-                        {
-                            "crs": "CRS84",
-                            "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
-                        }
-                    ]
-                }
-            },
-            "output-formats": [
+            "output_formats": [
                 "CoverageJSON",
                 "GeoJSON",
                 "IWXXM"
             ],
-            "parameters": {
+            "parameter_names": {
                 "Wind Direction": {
                     "type": "Parameter",
                     "description": "",
@@ -425,63 +423,12 @@
             },
             "crs": [
                 "CRS84"
-            ],
-            "data-queries": {
-                "position": {
-                    "title": "Position query",
-                    "description": "Position query",
-                    "output-formats": [
-                        "CoverageJSON",
-                        "GeoJSON"
-                    ],
-                    "default-output-format": "GeoJSON",
-                    "crs-details": [
-                        {
-                            "crs": "CRS84",
-                            "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
-                        }
-                    ]
-                },
-                "radius": {
-                    "title": "Radius query",
-                    "description": "Radius query",
-                    "output-formats": [
-                        "CoverageJSON",
-                        "GeoJSON"
-                    ],
-                    "default-output-format": "GeoJSON",
-                    "width-units": [
-                        "km",
-                        "miles"
-                    ],
-                    "crs-details": [
-                        {
-                            "crs": "CRS84",
-                            "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
-                        }
-                    ]
-                },
-                "area": {
-                    "title": "Area query",
-                    "description": "Area query",
-                    "output-formats": [
-                        "CoverageJSON",
-                        "GeoJSON"
-                    ],
-                    "default-output-format": "CoverageJSON",
-                    "crs-details": [
-                        {
-                            "crs": "CRS84",
-                            "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
-                        }
-                    ]
-                }
-            },
-            "output-formats": [
+           ],
+            "output_formats": [
                 "CoverageJSON",
                 "GeoJSON"
             ],
-            "parameter-names": {
+            "parameter_names": {
                 "Wind Direction": {
                     "type": "Parameter",
                     "description": "Direction wind is from",

--- a/candidate-standard/openapi/examples/collection.json
+++ b/candidate-standard/openapi/examples/collection.json
@@ -62,7 +62,6 @@
                     "href": "http://www.example.org/edr/collections/hrly_obs/position",
                     "hreflang": "en",
                     "rel": "data",
-                    "type": "position",
                     "title": "",
                     "variables": {
                         "title": "Position query",
@@ -85,7 +84,6 @@
                     "href": "http://www.example.org/edr/collections/hrly_obs/radius",
                     "hreflang": "en",
                     "rel": "data",
-                    "type": "radius",
                     "title": "",
                     "variables": {
                         "title": "Radius query",
@@ -112,7 +110,6 @@
                     "href": "http://www.example.org/edr/collections/hrly_obs/area",
                     "hreflang": "en",
                     "rel": "data",
-                    "type": "area",
                     "title": "",
                     "variables": {
                         "title": "Area query",
@@ -136,7 +133,6 @@
                     "href": "http://www.example.org/edr/collections/hrly_obs/locations",
                     "hreflang": "en",
                     "rel": "data",
-                    "type": "location",
                     "title": ""
                 }
             ],
@@ -400,7 +396,6 @@
                     "href": "http://www.example.org/edr/collections/3_hrly_fcst/instances",
                     "hreflang": "en",
                     "rel": "collection",
-                    "type": "instances",
                     "title": ""
                 }
             ],

--- a/candidate-standard/openapi/examples/collection.json
+++ b/candidate-standard/openapi/examples/collection.json
@@ -105,21 +105,21 @@
                 }
             },
             "crs": [
-                "EPSG:4326"
+                "CRS84"
             ],
-            "dataQueries": {
+            "data-queries": {
                 "position": {
                     "title": "Position query",
                     "description": "Position query",
-                    "outputformat": [
+                    "output-formats": [
                         "CoverageJSON",
                         "GeoJSON",
                         "IWXXM"
                     ],
-                    "defaultOutputFormat": "IWXXM",
-                    "crs": [
+                    "default-output-format": "IWXXM",
+                    "crs-details": [
                         {
-                            "name": "CRS84",
+                            "crs": "CRS84",
                             "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
                         }
                     ]
@@ -127,19 +127,19 @@
                 "radius": {
                     "title": "Radius query",
                     "description": "Radius query",
-                    "outputformat": [
+                    "output-formats": [
                         "CoverageJSON",
                         "GeoJSON",
                         "IWXXM"
                     ],
-                    "defaultOutputFormat": "GeoJSON",
+                    "default-output-format": "GeoJSON",
                     "width-units": [
                         "km",
                         "miles"
                     ],
-                    "crs": [
+                    "crs-details": [
                         {
-                            "name": "CRS84",
+                            "crs": "CRS84",
                             "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
                         }
                     ]
@@ -147,22 +147,22 @@
                 "area": {
                     "title": "Area query",
                     "description": "Area query",
-                    "outputformat": [
+                    "output-formats": [
                         "CoverageJSON",
                         "GeoJSON",
                         "BUFR",
                         "IWXXM"
                     ],
-                    "defaultOutputFormat": "CoverageJSON",
-                    "crs": [
+                    "default-output-format": "CoverageJSON",
+                    "crs-details": [
                         {
-                            "name": "CRS84",
+                            "crs": "CRS84",
                             "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
                         }
                     ]
                 }
             },
-            "outputformat": [
+            "output-formats": [
                 "CoverageJSON",
                 "GeoJSON",
                 "IWXXM"
@@ -170,13 +170,9 @@
             "parameters": {
                 "Wind Direction": {
                     "type": "Parameter",
-                    "description": {
-                        "en": ""
-                    },
+                    "description": "",
                     "unit": {
-                        "label": {
-                            "en": "degree true"
-                        },
+                        "label": "degree true",
                         "symbol": {
                             "value": "°",
                             "type": "http://www.example.org/edr/metadata/units/degree"
@@ -184,9 +180,7 @@
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/common/quantity-kind/_windDirection",
-                        "label": {
-                            "en": "Wind Direction"
-                        }
+                        "label":  "Wind Direction"
                     },
                     "measurementType": {
                         "method": "mean",
@@ -195,13 +189,9 @@
                 },
                 "Wind Speed": {
                     "type": "Parameter",
-                    "description": {
-                        "en": ""
-                    },
+                    "description": "",
                     "unit": {
-                        "label": {
-                            "en": "mph"
-                        },
+                        "label": "mph",
                         "symbol": {
                             "value": "mph",
                             "type": "http://www.example.org/edr/metadata/units/mph"
@@ -209,9 +199,7 @@
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/common/quantity-kind/_windSpeed",
-                        "label": {
-                            "en": "Wind Speed"
-                        }
+                        "label": "Wind Speed"
                     },
                     "measurementType": {
                         "method": "mean",
@@ -220,13 +208,9 @@
                 },
                 "Wind Gust": {
                     "type": "Parameter",
-                    "description": {
-                        "en": ""
-                    },
+                    "description": "",
                     "unit": {
-                        "label": {
-                            "en": "mph"
-                        },
+                        "label": "mph",
                         "symbol": {
                             "value": "mph",
                             "type": "http://www.example.org/edr/metadata/units/mph"
@@ -234,9 +218,7 @@
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/common/quantity-kind/_maximumWindGustSpeed",
-                        "label": {
-                            "en": "Wind Gust"
-                        }
+                        "label": "Wind Gust"
                     },
                     "measurementType": {
                         "method": "maximum",
@@ -245,13 +227,9 @@
                 },
                 "Air Temperature": {
                     "type": "Parameter",
-                    "description": {
-                        "en": ""
-                    },
+                    "description": "",
                     "unit": {
-                        "label": {
-                            "en": "degC"
-                        },
+                        "label":  "degC",
                         "symbol": {
                             "value": "°C",
                             "type": "http://www.example.org/edr/metadata/units/degC"
@@ -259,9 +237,7 @@
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/common/quantity-kind/_airTemperature",
-                        "label": {
-                            "en": "Air Temperature"
-                        }
+                        "label": "Air Temperature"
                     },
                     "measurementType": {
                         "method": "instantaneous",
@@ -270,13 +246,9 @@
                 },
                 "Weather": {
                     "type": "Parameter",
-                    "description": {
-                        "en": ""
-                    },
+                    "description": "",
                     "unit": {
-                        "label": {
-                            "en": "weather"
-                        },
+                        "label": "weather",
                         "symbol": {
                             "value": "",
                             "type": "http://www.example.org/edr/metadata/lookup/mo_dp_weather"
@@ -284,9 +256,7 @@
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/wmdr/ObservedVariableAtmosphere/_266",
-                        "label": {
-                            "en": "Weather"
-                        }
+                        "label": "Weather"
                     },
                     "measurementType": {
                         "method": "instantaneous",
@@ -295,13 +265,9 @@
                 },
                 "Relative Humidity": {
                     "type": "Parameter",
-                    "description": {
-                        "en": ""
-                    },
+                    "description": "",
                     "unit": {
-                        "label": {
-                            "en": "percent"
-                        },
+                        "label": "percent",
                         "symbol": {
                             "value": "%",
                             "type": "http://www.example.org/edr/metadata/units/percent"
@@ -309,9 +275,7 @@
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/bufr4/b/13/_009",
-                        "label": {
-                            "en": "Relative Humidity"
-                        }
+                        "label": "Relative Humidity"
                     },
                     "measurementType": {
                         "method": "instantaneous",
@@ -320,13 +284,9 @@
                 },
                 "Dew point": {
                     "type": "Parameter",
-                    "description": {
-                        "en": ""
-                    },
+                    "description": "",
                     "unit": {
-                        "label": {
-                            "en": "degC"
-                        },
+                        "label": "degC",
                         "symbol": {
                             "value": "°C",
                             "type": "http://www.example.org/edr/metadata/units/degC"
@@ -334,9 +294,7 @@
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/common/quantity-kind/_dewPointTemperature",
-                        "label": {
-                            "en": "Dew point"
-                        }
+                        "label": "Dew point"
                     },
                     "measurementType": {
                         "method": "instantaneous",
@@ -345,13 +303,9 @@
                 },
                 "Pressure": {
                     "type": "Parameter",
-                    "description": {
-                        "en": ""
-                    },
+                    "description": "",
                     "unit": {
-                        "label": {
-                            "en": "hPa"
-                        },
+                        "label": "hPa",
                         "symbol": {
                             "value": "hPa",
                             "type": "http://www.example.org/edr/metadata/units/hPa"
@@ -359,9 +313,7 @@
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/bufr4/b/10/_051",
-                        "label": {
-                            "en": "Pressure"
-                        }
+                        "label": "Pressure"
                     },
                     "measurementType": {
                         "method": "instantaneous",
@@ -370,13 +322,9 @@
                 },
                 "Pressure Tendancy": {
                     "type": "Parameter",
-                    "description": {
-                        "en": ""
-                    },
+                    "description": "",
                     "unit": {
-                        "label": {
-                            "en": "tendency"
-                        },
+                        "label": "tendency",
                         "symbol": {
                             "value": "",
                             "type": "http://www.example.org/edr/metadata/units/hPa"
@@ -384,9 +332,7 @@
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/common/quantity-kind/_pressureTendency",
-                        "label": {
-                            "en": "Pressure Tendancy"
-                        }
+                        "label": "Pressure Tendancy"
                     },
                     "measurementType": {
                         "method": "instantaneous",
@@ -395,13 +341,9 @@
                 },
                 "Visibility": {
                     "type": "Parameter",
-                    "description": {
-                        "en": ""
-                    },
+                    "description": "",
                     "unit": {
-                        "label": {
-                            "en": "m"
-                        },
+                        "label": "m",
                         "symbol": {
                             "value": "m",
                             "type": "http://www.example.org/edr/metadata/units/m"
@@ -409,9 +351,7 @@
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/common/quantity-kind/_horizontalVisibility",
-                        "label": {
-                            "en": "Visibility"
-                        }
+                        "label": "Visibility"
                     },
                     "measurementType": {
                         "method": "instantaneous",
@@ -484,20 +424,20 @@
                 }
             },
             "crs": [
-                "EPSG:4326"
+                "CRS84"
             ],
-            "dataQueries": {
+            "data-queries": {
                 "position": {
                     "title": "Position query",
                     "description": "Position query",
-                    "outputformat": [
+                    "output-formats": [
                         "CoverageJSON",
                         "GeoJSON"
                     ],
-                    "defaultOutputFormat": "GeoJSON",
-                    "crs": [
+                    "default-output-format": "GeoJSON",
+                    "crs-details": [
                         {
-                            "name": "CRS84",
+                            "crs": "CRS84",
                             "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
                         }
                     ]
@@ -505,18 +445,18 @@
                 "radius": {
                     "title": "Radius query",
                     "description": "Radius query",
-                    "outputformat": [
+                    "output-formats": [
                         "CoverageJSON",
                         "GeoJSON"
                     ],
-                    "defaultOutputFormat": "GeoJSON",
+                    "default-output-format": "GeoJSON",
                     "width-units": [
                         "km",
                         "miles"
                     ],
-                    "crs": [
+                    "crs-details": [
                         {
-                            "name": "CRS84",
+                            "crs": "CRS84",
                             "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
                         }
                     ]
@@ -524,33 +464,29 @@
                 "area": {
                     "title": "Area query",
                     "description": "Area query",
-                    "outputformat": [
+                    "output-formats": [
                         "CoverageJSON",
                         "GeoJSON"
                     ],
-                    "defaultOutputFormat": "CoverageJSON",
-                    "crs": [
+                    "default-output-format": "CoverageJSON",
+                    "crs-details": [
                         {
-                            "name": "CRS84",
+                            "crs": "CRS84",
                             "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
                         }
                     ]
                 }
             },
-            "outputformat": [
+            "output-formats": [
                 "CoverageJSON",
                 "GeoJSON"
             ],
             "parameter-names": {
                 "Wind Direction": {
                     "type": "Parameter",
-                    "description": {
-                        "en": "Direction wind is from"
-                    },
+                    "description": "Direction wind is from",
                     "unit": {
-                        "label": {
-                            "en": "degree true"
-                        },
+                        "label": "degree true",
                         "symbol": {
                             "value": "°",
                             "type": "http://www.example.org/edr/metadata/units/degree"
@@ -558,10 +494,8 @@
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/grib2/codeflag/4.2/_0-2-0",
-                        "label": {
-                            "en": "Wind Direction"
-                        }
-                    },
+                        "label": "Wind Direction"
+                                            },
                     "measurementType": {
                         "method": "mean",
                         "period": "-PT10M/PT0M"
@@ -569,13 +503,9 @@
                 },
                 "Wind Speed": {
                     "type": "Parameter",
-                    "description": {
-                        "en": "Average wind speed"
-                    },
+                    "description":"Average wind speed",
                     "unit": {
-                        "label": {
-                            "en": "mph"
-                        },
+                        "label": "mph",
                         "symbol": {
                             "value": "mph",
                             "type": "http://www.example.org/edr/metadata/units/mph"
@@ -583,9 +513,7 @@
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/grib2/codeflag/4.2/_0-2-1",
-                        "label": {
-                            "en": "Wind Speed"
-                        }
+                        "label":  "Wind Speed"
                     },
                     "measurementType": {
                         "method": "mean",
@@ -594,13 +522,9 @@
                 },
                 "Wind Gust": {
                     "type": "Parameter",
-                    "description": {
-                        "en": "Wind gusts are a rapid increase in strength of the wind relative to the wind speed."
-                    },
+                    "description":  "Wind gusts are a rapid increase in strength of the wind relative to the wind speed.",
                     "unit": {
-                        "label": {
-                            "en": "mph"
-                        },
+                        "label": "mph",
                         "symbol": {
                             "value": "mph",
                             "type": "http://www.example.org/edr/metadata/units/mph"
@@ -608,9 +532,7 @@
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/grib2/codeflag/4.2/_0-2-1",
-                        "label": {
-                            "en": "Wind Gust"
-                        }
+                        "label": "Wind Gust"
                     },
                     "measurementType": {
                         "method": "maximum",
@@ -619,13 +541,9 @@
                 },
                 "Air Temperature": {
                     "type": "Parameter",
-                    "description": {
-                        "en": "2m air temperature in the shade and out of the wind"
-                    },
+                    "description":  "2m air temperature in the shade and out of the wind",
                     "unit": {
-                        "label": {
-                            "en": "degC"
-                        },
+                        "label":  "degC",
                         "symbol": {
                             "value": "°C",
                             "type": "http://www.example.org/edr/metadata/units/degC"
@@ -633,9 +551,7 @@
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/common/quantity-kind/_airTemperature",
-                        "label": {
-                            "en": "Air Temperature"
-                        }
+                        "label": "Air Temperature"
                     },
                     "measurementType": {
                         "method": "instantaneous",
@@ -644,13 +560,9 @@
                 },
                 "Weather": {
                     "type": "Parameter",
-                    "description": {
-                        "en": ""
-                    },
+                    "description": "",
                     "unit": {
-                        "label": {
-                            "en": "weather"
-                        },
+                        "label":  "weather",
                         "symbol": {
                             "value": "",
                             "type": "http://www.example.org/edr/metadata/lookup/mo_dp_weather"
@@ -658,9 +570,7 @@
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/wmdr/ObservedVariableAtmosphere/_266",
-                        "label": {
-                            "en": "Weather"
-                        }
+                        "label": "Weather"
                     },
                     "measurementType": {
                         "method": "instantaneous",
@@ -669,13 +579,9 @@
                 },
                 "Relative Humidity": {
                     "type": "Parameter",
-                    "description": {
-                        "en": ""
-                    },
+                    "description": "",
                     "unit": {
-                        "label": {
-                            "en": "percent"
-                        },
+                        "label": "percent",
                         "symbol": {
                             "value": "%",
                             "type": "http://www.example.org/edr/metadata/units/percent"
@@ -683,9 +589,7 @@
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/grib2/codeflag/4.2/_0-1-1",
-                        "label": {
-                            "en": "Relative Humidity"
-                        }
+                        "label":  "Relative Humidity"
                     },
                     "measurementType": {
                         "method": "instantaneous",
@@ -694,13 +598,9 @@
                 },
                 "Feels like temperature": {
                     "type": "Parameter",
-                    "description": {
-                        "en": ""
-                    },
+                    "description": "",
                     "unit": {
-                        "label": {
-                            "en": "degC"
-                        },
+                        "label": "degC",
                         "symbol": {
                             "value": "°C",
                             "type": "http://www.example.org/edr/metadata/units/degC"
@@ -708,9 +608,7 @@
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/common/quantity-kind/_airTemperature",
-                        "label": {
-                            "en": "Feels like temperature"
-                        }
+                        "label": "Feels like temperature"
                     },
                     "measurementType": {
                         "method": "instantaneous",
@@ -719,13 +617,9 @@
                 },
                 "UV index": {
                     "type": "Parameter",
-                    "description": {
-                        "en": ""
-                    },
+                    "description": "",
                     "unit": {
-                        "label": {
-                            "en": "UV_index"
-                        },
+                        "label":  "UV_index",
                         "symbol": {
                             "value": "",
                             "type": "http://www.example.org/edr/metadata/lookup/mo_dp_uv"
@@ -733,9 +627,7 @@
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/grib2/codeflag/4.2/_0-4-51",
-                        "label": {
-                            "en": "UV index"
-                        }
+                        "label": "UV index"
                     },
                     "measurementType": {
                         "method": "instantaneous",
@@ -744,13 +636,9 @@
                 },
                 "Probabilty of precipitation": {
                     "type": "Parameter",
-                    "description": {
-                        "en": ""
-                    },
+                    "description": "",
                     "unit": {
-                        "label": {
-                            "en": "percent"
-                        },
+                        "label": "percent",
                         "symbol": {
                             "value": "%",
                             "type": "http://www.example.org/edr/metadata/units/percent"
@@ -758,9 +646,7 @@
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/grib2/codeflag/4.2/_0-1-1",
-                        "label": {
-                            "en": "Probabilty of precipitation"
-                        }
+                        "label": "Probabilty of precipitation"
                     },
                     "measurementType": {
                         "method": "instantaneous",
@@ -769,13 +655,9 @@
                 },
                 "Visibility": {
                     "type": "Parameter",
-                    "description": {
-                        "en": ""
-                    },
+                    "description": "",
                     "unit": {
-                        "label": {
-                            "en": "quality"
-                        },
+                        "label": "quality",
                         "symbol": {
                             "value": "",
                             "type": "http://www.example.org/edr/metadata/lookup/mo_dp_visibility"
@@ -783,9 +665,7 @@
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/common/quantity-kind/_horizontalVisibility",
-                        "label": {
-                            "en": "Visibility"
-                        }
+                        "label":  "Visibility"
                     },
                     "measurementType": {
                         "method": "instantaneous",

--- a/candidate-standard/openapi/examples/collection.json
+++ b/candidate-standard/openapi/examples/collection.json
@@ -101,7 +101,7 @@
                             "IWXXM"
                         ],
                         "default_output_format": "GeoJSON",
-                        "width_units": [
+                        "within_units": [
                             "km",
                             "miles"
                         ],

--- a/candidate-standard/openapi/examples/collection.json
+++ b/candidate-standard/openapi/examples/collection.json
@@ -60,11 +60,11 @@
                     "hreflang": "en",
                     "rel": "data",
                     "title": "",
+                    "templated": true,
                     "variables": {
                         "title": "Position query",
                         "description": "Position query",
                         "query_type": "position",
-                        "templated": true,
                         "coords" :{
                             "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
                         },
@@ -87,11 +87,11 @@
                     "hreflang": "en",
                     "rel": "data",
                     "title": "",
+                    "templated": true,
                     "variables": {
                         "title": "Radius query",
                         "description": "Radius query",
                         "query_type": "radius",
-                        "templated": true,
                         "coords" :{
                             "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
                         },
@@ -118,11 +118,11 @@
                     "hreflang": "en",
                     "rel": "data",
                     "title": "",
+                    "templated": true,
                     "variables": {
                         "title": "Area query",
                         "description": "Area query",
                         "query_type": "area",
-                        "templated": true,
                         "coords" :{
                             "description": "Well Known Text POLYGON value i.e. POLYGON((-79 40,-79 38,-75 38,-75 41,-79 40))"
                         },
@@ -145,11 +145,11 @@
                     "href": "http://www.example.org/edr/collections/hrly_obs/locations",
                     "hreflang": "en",
                     "rel": "data",
+                    "templated": false,
                     "variables": {
                         "title": "Location query",
                         "description": "Location query",
                         "query_type": "locations",
-                        "templated": false,
                         "output_formats": [
                             "CoverageJSON",
                             "GeoJSON",

--- a/candidate-standard/openapi/examples/collection.json
+++ b/candidate-standard/openapi/examples/collection.json
@@ -66,6 +66,7 @@
                     "variables": {
                         "title": "Position query",
                         "description": "Position query",
+                        "query_type": "position",
                         "output_formats": [
                             "CoverageJSON",
                             "GeoJSON",
@@ -88,6 +89,7 @@
                     "variables": {
                         "title": "Radius query",
                         "description": "Radius query",
+                        "query_type": "radius",
                         "output_formats": [
                             "CoverageJSON",
                             "GeoJSON",
@@ -114,6 +116,7 @@
                     "variables": {
                         "title": "Area query",
                         "description": "Area query",
+                        "query_type": "area",
                         "output_formats": [
                             "CoverageJSON",
                             "GeoJSON",

--- a/candidate-standard/openapi/examples/collection.json
+++ b/candidate-standard/openapi/examples/collection.json
@@ -41,25 +41,22 @@
                     "href": "http://www.example.org/uk-hourly-site-specific-observations",
                     "hreflang": "en",
                     "rel": "service-doc",
-                    "type": "text/html",
-                    "title": ""
+                    "type": "text/html"
                 },
                 {
                     "href": "http://www.example.org/terms-and-conditions---datapoint#datalicence",
                     "hreflang": "en",
                     "rel": "license",
-                    "type": "text/html",
-                    "title": ""
+                    "type": "text/html"
                 },
                 {
                     "href": "https://www.metoffice.gov.uk/services/data/datapoint/terms-and-conditions---datapoint#termsofservice",
                     "hreflang": "en",
                     "rel": "restrictions",
-                    "type": "text/html",
-                    "title": ""
+                    "type": "text/html"
                 },
                 {
-                    "href": "http://www.example.org/edr/collections/hrly_obs/position",
+                    "href": "http://www.example.org/edr/collections/hrly_obs/position?coords={coords}",
                     "hreflang": "en",
                     "rel": "data",
                     "title": "",
@@ -67,6 +64,10 @@
                         "title": "Position query",
                         "description": "Position query",
                         "query_type": "position",
+                        "templated": true,
+                        "coords" :{
+                            "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
+                        },
                         "output_formats": [
                             "CoverageJSON",
                             "GeoJSON",
@@ -82,7 +83,7 @@
                     }
                 },
                 {
-                    "href": "http://www.example.org/edr/collections/hrly_obs/radius",
+                    "href": "http://www.example.org/edr/collections/hrly_obs/radius?coords={coords}",
                     "hreflang": "en",
                     "rel": "data",
                     "title": "",
@@ -90,6 +91,10 @@
                         "title": "Radius query",
                         "description": "Radius query",
                         "query_type": "radius",
+                        "templated": true,
+                        "coords" :{
+                            "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
+                        },
                         "output_formats": [
                             "CoverageJSON",
                             "GeoJSON",
@@ -109,7 +114,7 @@
                     }
                 },
                 {
-                    "href": "http://www.example.org/edr/collections/hrly_obs/area",
+                    "href": "http://www.example.org/edr/collections/hrly_obs/area?coords={coords}",
                     "hreflang": "en",
                     "rel": "data",
                     "title": "",
@@ -117,6 +122,10 @@
                         "title": "Area query",
                         "description": "Area query",
                         "query_type": "area",
+                        "templated": true,
+                        "coords" :{
+                            "description": "Well Known Text POLYGON value i.e. POLYGON((-79 40,-79 38,-75 38,-75 41,-79 40))"
+                        },
                         "output_formats": [
                             "CoverageJSON",
                             "GeoJSON",
@@ -136,7 +145,25 @@
                     "href": "http://www.example.org/edr/collections/hrly_obs/locations",
                     "hreflang": "en",
                     "rel": "data",
-                    "title": ""
+                    "variables": {
+                        "title": "Location query",
+                        "description": "Location query",
+                        "query_type": "locations",
+                        "templated": false,
+                        "output_formats": [
+                            "CoverageJSON",
+                            "GeoJSON",
+                            "BUFR",
+                            "IWXXM"
+                        ],
+                        "default_output_format": "CoverageJSON",
+                        "crs_details": [
+                            {
+                                "crs": "CRS84",
+                                "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
+                            }
+                        ]    
+                    }
                 }
             ],
             "extent": {
@@ -378,28 +405,24 @@
                     "href": "https://http://www.example.org/uk-3-hourly-site-specific-forecast",
                     "hreflang": "en",
                     "rel": "service-doc",
-                    "type": "text/html",
-                    "title": ""
+                    "type": "text/html"
                 },
                 {
                     "href": "https://http://www.example.org/terms-and-conditions---datapoint#datalicence",
                     "hreflang": "en",
                     "rel": "licence",
-                    "type": "text/html",
-                    "title": ""
+                    "type": "text/html"
                 },
                 {
                     "href": "https://http://www.example.org/terms-and-conditions---datapoint#termsofservice",
                     "hreflang": "en",
                     "rel": "restrictions",
-                    "type": "text/html",
-                    "title": ""
+                    "type": "text/html"
                 },
                 {
                     "href": "http://www.example.org/edr/collections/3_hrly_fcst/instances",
                     "hreflang": "en",
-                    "rel": "collection",
-                    "title": ""
+                    "rel": "collection"
                 }
             ],
             "extent": {

--- a/candidate-standard/openapi/examples/collection.json
+++ b/candidate-standard/openapi/examples/collection.json
@@ -56,114 +56,24 @@
                     "type": "text/html"
                 },
                 {
-                    "href": "http://www.example.org/edr/collections/hrly_obs/position?coords={coords}",
+                    "href": "http://www.example.org/edr/collections/hrly_obs/position",
                     "hreflang": "en",
-                    "rel": "data",
-                    "title": "",
-                    "templated": true,
-                    "variables": {
-                        "title": "Position query",
-                        "description": "Position query",
-                        "query_type": "position",
-                        "coords" :{
-                            "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
-                        },
-                        "output_formats": [
-                            "CoverageJSON",
-                            "GeoJSON",
-                            "IWXXM"
-                        ],
-                        "default_output_format": "IWXXM",
-                        "crs_details": [
-                            {
-                                "crs": "CRS84",
-                                "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
-                            }
-                        ]    
-                    }
+                    "rel": "data"
                 },
                 {
-                    "href": "http://www.example.org/edr/collections/hrly_obs/radius?coords={coords}",
+                    "href": "http://www.example.org/edr/collections/hrly_obs/radius",
                     "hreflang": "en",
-                    "rel": "data",
-                    "title": "",
-                    "templated": true,
-                    "variables": {
-                        "title": "Radius query",
-                        "description": "Radius query",
-                        "query_type": "radius",
-                        "coords" :{
-                            "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
-                        },
-                        "output_formats": [
-                            "CoverageJSON",
-                            "GeoJSON",
-                            "IWXXM"
-                        ],
-                        "default_output_format": "GeoJSON",
-                        "within_units": [
-                            "km",
-                            "miles"
-                        ],
-                        "crs_details": [
-                            {
-                                "crs": "CRS84",
-                                "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
-                            }
-                        ]    
-                    }
+                    "rel": "data"
                 },
                 {
-                    "href": "http://www.example.org/edr/collections/hrly_obs/area?coords={coords}",
+                    "href": "http://www.example.org/edr/collections/hrly_obs/area",
                     "hreflang": "en",
-                    "rel": "data",
-                    "title": "",
-                    "templated": true,
-                    "variables": {
-                        "title": "Area query",
-                        "description": "Area query",
-                        "query_type": "area",
-                        "coords" :{
-                            "description": "Well Known Text POLYGON value i.e. POLYGON((-79 40,-79 38,-75 38,-75 41,-79 40))"
-                        },
-                        "output_formats": [
-                            "CoverageJSON",
-                            "GeoJSON",
-                            "BUFR",
-                            "IWXXM"
-                        ],
-                        "default_output_format": "CoverageJSON",
-                        "crs_details": [
-                            {
-                                "crs": "CRS84",
-                                "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
-                            }
-                        ]    
-                    }
+                    "rel": "data"
                 },
                 {
                     "href": "http://www.example.org/edr/collections/hrly_obs/locations",
                     "hreflang": "en",
-                    "rel": "data",
-                    "templated": false,
-                    "variables": {
-                        "title": "Location query",
-                        "description": "Location query",
-                        "query_type": "locations",
-                        "output_formats": [
-                            "CoverageJSON",
-                            "GeoJSON",
-                            "BUFR",
-                            "IWXXM"
-                        ],
-                        "default_output_format": "CoverageJSON",
-                        "crs_details": [
-                            {
-                                "crs": "CRS84",
-                                "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
-                            }
-                        ]    
-                    }
+                    "rel": "data"
                 }
             ],
             "extent": {
@@ -181,6 +91,123 @@
                         "2020-04-19T11:00:00Z/2020-06-30T09:00:00Z"
                     ],
                     "trs": "TIMECRS[\"DateTime\",TDATUM[\"Gregorian Calendar\"],CS[TemporalDateTime,1],AXIS[\"Time (T)\",future]"
+                }
+            },
+            "data_queries" : {
+                "position": {
+                    "link": {
+                        "href": "http://www.example.org/edr/collections/hrly_obs/position?coords={coords}",
+                        "hreflang": "en",
+                        "rel": "data",
+                        "templated": true,
+                        "variables": {
+                            "title": "Position query",
+                            "description": "Position query",
+                            "query_type": "position",
+                            "coords" :{
+                                "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
+                            },
+                            "output_formats": [
+                                "CoverageJSON",
+                                "GeoJSON",
+                                "IWXXM"
+                            ],
+                            "default_output_format": "IWXXM",
+                            "crs_details": [
+                                {
+                                    "crs": "CRS84",
+                                    "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
+                                }
+                            ]    
+                        }
+                    }                    
+                },
+                "radius": {
+                    "link": {
+                        "href": "http://www.example.org/edr/collections/hrly_obs/radius?coords={coords}",
+                        "hreflang": "en",
+                        "rel": "data",
+                        "templated": true,
+                        "variables": {
+                            "title": "Radius query",
+                            "description": "Radius query",
+                            "query_type": "radius",
+                            "coords" :{
+                                "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
+                            },
+                            "output_formats": [
+                                "CoverageJSON",
+                                "GeoJSON",
+                                "IWXXM"
+                            ],
+                            "default_output_format": "GeoJSON",
+                            "within_units": [
+                                "km",
+                                "miles"
+                            ],
+                            "crs_details": [
+                                {
+                                    "crs": "CRS84",
+                                    "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
+                                }
+                            ]    
+                        }
+                    }                  
+                },
+                "area": {
+                    "link":                 {
+                        "href": "http://www.example.org/edr/collections/hrly_obs/area?coords={coords}",
+                        "hreflang": "en",
+                        "rel": "data",
+                        "templated": true,
+                        "variables": {
+                            "title": "Area query",
+                            "description": "Area query",
+                            "query_type": "area",
+                            "coords" :{
+                                "description": "Well Known Text POLYGON value i.e. POLYGON((-79 40,-79 38,-75 38,-75 41,-79 40))"
+                            },
+                            "output_formats": [
+                                "CoverageJSON",
+                                "GeoJSON",
+                                "BUFR",
+                                "IWXXM"
+                            ],
+                            "default_output_format": "CoverageJSON",
+                            "crs_details": [
+                                {
+                                    "crs": "CRS84",
+                                    "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
+                                }
+                            ]    
+                        }
+                    }
+                },
+                "locations": {
+                    "link": {
+                        "href": "http://www.example.org/edr/collections/hrly_obs/locations",
+                        "hreflang": "en",
+                        "rel": "data",
+                        "templated": false,
+                        "variables": {
+                            "title": "Location query",
+                            "description": "Location query",
+                            "query_type": "locations",
+                            "output_formats": [
+                                "CoverageJSON",
+                                "GeoJSON",
+                                "BUFR",
+                                "IWXXM"
+                            ],
+                            "default_output_format": "CoverageJSON",
+                            "crs_details": [
+                                {
+                                    "crs": "CRS84",
+                                    "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
+                                }
+                            ]    
+                        }
+                    }                    
                 }
             },
             "crs": [

--- a/candidate-standard/openapi/examples/instance.json
+++ b/candidate-standard/openapi/examples/instance.json
@@ -59,7 +59,7 @@
             ],
             "links": [
                 {
-                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/position",
+                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/position?coords={coords}",
                     "hreflang": "en",
                     "rel": "data",
                     "title": "",
@@ -67,6 +67,10 @@
                         "title": "Position query",
                         "description": "Position query",
                         "query_type": "position",
+                        "templated": true,
+                        "coords" :{
+                            "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
+                        },                        
                         "output_formats": [
                             "CoverageJSON",
                             "GeoJSON"
@@ -82,14 +86,17 @@
 
                 },
                 {
-                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/radius",
+                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/radius?coords={coords}",
                     "hreflang": "en",
                     "rel": "data",
-                    "title": "",
                     "variables": {
                         "title": "Radius query",
                         "description": "Radius query",
                         "query_type": "radius",
+                        "templated": true,
+                        "coords" :{
+                            "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
+                        },                        
                         "output_formats": [
                             "CoverageJSON",
                             "GeoJSON",
@@ -110,14 +117,17 @@
 
                 },
                 {
-                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/area",
+                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/area?coords={coords}",
                     "hreflang": "en",
                     "rel": "data",
-                    "title": "",
                     "variables": {
                         "title": "Area query",
                         "description": "Area query",
                         "query_type": "area",
+                        "templated": true,
+                        "coords" :{
+                            "description": "Well Known Text POLYGON value i.e. POLYGON((-79 40,-79 38,-75 38,-75 41,-79 40))"
+                        },
                         "output_formats": [
                             "CoverageJSON",
                             "GeoJSON",
@@ -137,7 +147,23 @@
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/locations",
                     "hreflang": "en",
                     "rel": "data",
-                    "title": ""
+                    "variables": {
+                        "title": "Locations query",
+                        "description": "Locations query",
+                        "query_type": "location",
+                        "templated": false,
+                        "output_formats": [
+                            "CoverageJSON",
+                            "GeoJSON"
+                        ],
+                        "default_output_format": "GeoJSON",
+                        "crs_details": [
+                            {
+                                "crs": "CRS84",
+                                "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
+                            }
+                        ]    
+                    }
                 }
             ],
             "extent": {
@@ -374,14 +400,17 @@
             ],
             "links": [
                 {
-                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/position",
+                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/position?coords={coords}",
                     "hreflang": "en",
                     "rel": "data",
-                    "title": "",
                     "variables": {
                         "title": "Position query",
                         "description": "Position query",
                         "query_type": "position",
+                        "templated": true,
+                        "coords" :{
+                            "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
+                        },                        
                         "output_formats": [
                             "CoverageJSON",
                             "GeoJSON"
@@ -397,7 +426,7 @@
 
                 },
                 {
-                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/radius",
+                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/radius?coords={coords}",
                     "hreflang": "en",
                     "rel": "data",
                     "title": "",
@@ -405,6 +434,10 @@
                         "title": "Radius query",
                         "description": "Radius query",
                         "query_type": "radius",
+                        "templated": true,
+                        "coords" :{
+                            "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
+                        },
                         "output_formats": [
                             "CoverageJSON",
                             "GeoJSON",
@@ -425,7 +458,7 @@
 
                 },
                 {
-                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/area",
+                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/area?coords={coords}",
                     "hreflang": "en",
                     "rel": "data",
                     "title": "",
@@ -433,6 +466,10 @@
                         "title": "Area query",
                         "description": "Area query",
                         "query_type": "area",
+                        "templated": true,
+                        "coords" :{
+                            "description": "Well Known Text POLYGON value i.e. POLYGON((-79 40,-79 38,-75 38,-75 41,-79 40))"
+                        },
                         "output_formats": [
                             "CoverageJSON",
                             "GeoJSON",
@@ -452,7 +489,23 @@
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/locations",
                     "hreflang": "en",
                     "rel": "data",
-                    "title": ""
+                    "variables": {
+                        "title": "Locations query",
+                        "description": "Locations query",
+                        "query_type": "location",
+                        "templated": false,
+                        "output_formats": [
+                            "CoverageJSON",
+                            "GeoJSON"
+                        ],
+                        "default_output_format": "GeoJSON",
+                        "crs_details": [
+                            {
+                                "crs": "CRS84",
+                                "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
+                            }
+                        ]    
+                    }
                 }
             ],
             "extent": {
@@ -689,14 +742,17 @@
             ],
             "links": [
                 {
-                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/position",
+                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/position?coords={coords}",
                     "hreflang": "en",
                     "rel": "data",
-                    "title": "",
                     "variables": {
                         "title": "Position query",
                         "description": "Position query",
                         "query_type": "position",
+                        "templated": true,
+                        "coords" :{
+                            "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
+                        },
                         "output_formats": [
                             "CoverageJSON",
                             "GeoJSON"
@@ -712,14 +768,17 @@
 
                 },
                 {
-                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/radius",
+                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/radius?coords={coords}",
                     "hreflang": "en",
                     "rel": "data",
-                    "title": "",
                     "variables": {
                         "title": "Radius query",
                         "description": "Radius query",
                         "query_type": "radius",
+                        "templated": true,
+                        "coords" :{
+                            "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
+                        },
                         "output_formats": [
                             "CoverageJSON",
                             "GeoJSON",
@@ -740,14 +799,17 @@
 
                 },
                 {
-                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/area",
+                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/area?coords={coords}",
                     "hreflang": "en",
                     "rel": "data",
-                    "title": "",
                     "variables": {
                         "title": "Area query",
                         "description": "Area query",
                         "query_type": "area",
+                        "templated": true,
+                        "coords" :{
+                            "description": "Well Known Text POLYGON value i.e. POLYGON((-79 40,-79 38,-75 38,-75 41,-79 40))"
+                        },
                         "output_formats": [
                             "CoverageJSON",
                             "GeoJSON",
@@ -767,7 +829,23 @@
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/locations",
                     "hreflang": "en",
                     "rel": "data",
-                    "title": ""
+                    "variables": {
+                        "title": "Locations query",
+                        "description": "Locations query",
+                        "query_type": "location",
+                        "templated": false,
+                        "output_formats": [
+                            "CoverageJSON",
+                            "GeoJSON"
+                        ],
+                        "default_output_format": "GeoJSON",
+                        "crs_details": [
+                            {
+                                "crs": "CRS84",
+                                "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
+                            }
+                        ]    
+                    }
                 }
             ],
             "extent": {
@@ -1004,14 +1082,17 @@
             ],
             "links": [
                 {
-                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/position",
+                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/position?coords={coords}",
                     "hreflang": "en",
                     "rel": "data",
-                    "title": "",
                     "variables": {
                         "title": "Position query",
                         "description": "Position query",
                         "query_type": "position",
+                        "templated": true,
+                        "coords" :{
+                            "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
+                        },
                         "output_formats": [
                             "CoverageJSON",
                             "GeoJSON"
@@ -1027,7 +1108,7 @@
 
                 },
                 {
-                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/radius",
+                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/radius?coords={coords}",
                     "hreflang": "en",
                     "rel": "data",
                     "title": "",
@@ -1035,6 +1116,10 @@
                         "title": "Radius query",
                         "description": "Radius query",
                         "query_type": "radius",
+                        "templated": true,
+                        "coords" :{
+                            "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
+                        },
                         "output_formats": [
                             "CoverageJSON",
                             "GeoJSON",
@@ -1055,14 +1140,17 @@
 
                 },
                 {
-                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/area",
+                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/area?coords={coords}",
                     "hreflang": "en",
                     "rel": "data",
-                    "title": "",
                     "variables": {
                         "title": "Area query",
                         "description": "Area query",
                         "query_type": "area",
+                        "templated": true,
+                        "coords" :{
+                            "description": "Well Known Text POLYGON value i.e. POLYGON((-79 40,-79 38,-75 38,-75 41,-79 40))"
+                        },
                         "output_formats": [
                             "CoverageJSON",
                             "GeoJSON",
@@ -1082,7 +1170,23 @@
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/locations",
                     "hreflang": "en",
                     "rel": "data",
-                    "title": ""
+                    "variables": {
+                        "title": "Locations query",
+                        "description": "Locations query",
+                        "query_type": "location",
+                        "templated": false,
+                        "output_formats": [
+                            "CoverageJSON",
+                            "GeoJSON"
+                        ],
+                        "default_output_format": "GeoJSON",
+                        "crs_details": [
+                            {
+                                "crs": "CRS84",
+                                "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
+                            }
+                        ]    
+                    }
                 }
             ],
             "extent": {

--- a/candidate-standard/openapi/examples/instance.json
+++ b/candidate-standard/openapi/examples/instance.json
@@ -62,7 +62,6 @@
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/position",
                     "hreflang": "en",
                     "rel": "data",
-                    "type": "position",
                     "title": "",
                     "variables": {
                         "title": "Position query",
@@ -85,7 +84,6 @@
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/radius",
                     "hreflang": "en",
                     "rel": "data",
-                    "type": "radius",
                     "title": "",
                     "variables": {
                         "title": "Radius query",
@@ -113,7 +111,6 @@
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/area",
                     "hreflang": "en",
                     "rel": "data",
-                    "type": "area",
                     "title": "",
                     "variables": {
                         "title": "Area query",
@@ -137,7 +134,6 @@
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/locations",
                     "hreflang": "en",
                     "rel": "data",
-                    "type": "location",
                     "title": ""
                 }
             ],
@@ -378,7 +374,6 @@
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/position",
                     "hreflang": "en",
                     "rel": "data",
-                    "type": "position",
                     "title": "",
                     "variables": {
                         "title": "Position query",
@@ -401,7 +396,6 @@
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/radius",
                     "hreflang": "en",
                     "rel": "data",
-                    "type": "radius",
                     "title": "",
                     "variables": {
                         "title": "Radius query",
@@ -429,7 +423,6 @@
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/area",
                     "hreflang": "en",
                     "rel": "data",
-                    "type": "area",
                     "title": "",
                     "variables": {
                         "title": "Area query",
@@ -453,7 +446,6 @@
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/locations",
                     "hreflang": "en",
                     "rel": "data",
-                    "type": "location",
                     "title": ""
                 }
             ],
@@ -694,7 +686,6 @@
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/position",
                     "hreflang": "en",
                     "rel": "data",
-                    "type": "position",
                     "title": "",
                     "variables": {
                         "title": "Position query",
@@ -717,7 +708,6 @@
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/radius",
                     "hreflang": "en",
                     "rel": "data",
-                    "type": "radius",
                     "title": "",
                     "variables": {
                         "title": "Radius query",
@@ -745,7 +735,6 @@
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/area",
                     "hreflang": "en",
                     "rel": "data",
-                    "type": "area",
                     "title": "",
                     "variables": {
                         "title": "Area query",
@@ -769,7 +758,6 @@
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/locations",
                     "hreflang": "en",
                     "rel": "data",
-                    "type": "location",
                     "title": ""
                 }
             ],
@@ -1010,7 +998,6 @@
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/position",
                     "hreflang": "en",
                     "rel": "data",
-                    "type": "position",
                     "title": "",
                     "variables": {
                         "title": "Position query",
@@ -1033,7 +1020,6 @@
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/radius",
                     "hreflang": "en",
                     "rel": "data",
-                    "type": "radius",
                     "title": "",
                     "variables": {
                         "title": "Radius query",
@@ -1061,7 +1047,6 @@
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/area",
                     "hreflang": "en",
                     "rel": "data",
-                    "type": "area",
                     "title": "",
                     "variables": {
                         "title": "Area query",
@@ -1085,7 +1070,6 @@
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/locations",
                     "hreflang": "en",
                     "rel": "data",
-                    "type": "location",
                     "title": ""
                 }
             ],

--- a/candidate-standard/openapi/examples/instance.json
+++ b/candidate-standard/openapi/examples/instance.json
@@ -66,6 +66,7 @@
                     "variables": {
                         "title": "Position query",
                         "description": "Position query",
+                        "query_type": "position",
                         "output_formats": [
                             "CoverageJSON",
                             "GeoJSON"
@@ -88,6 +89,7 @@
                     "variables": {
                         "title": "Radius query",
                         "description": "Radius query",
+                        "query_type": "radius",
                         "output_formats": [
                             "CoverageJSON",
                             "GeoJSON",
@@ -115,6 +117,7 @@
                     "variables": {
                         "title": "Area query",
                         "description": "Area query",
+                        "query_type": "area",
                         "output_formats": [
                             "CoverageJSON",
                             "GeoJSON",
@@ -378,6 +381,7 @@
                     "variables": {
                         "title": "Position query",
                         "description": "Position query",
+                        "query_type": "position",
                         "output_formats": [
                             "CoverageJSON",
                             "GeoJSON"
@@ -400,6 +404,7 @@
                     "variables": {
                         "title": "Radius query",
                         "description": "Radius query",
+                        "query_type": "radius",
                         "output_formats": [
                             "CoverageJSON",
                             "GeoJSON",
@@ -427,6 +432,7 @@
                     "variables": {
                         "title": "Area query",
                         "description": "Area query",
+                        "query_type": "area",
                         "output_formats": [
                             "CoverageJSON",
                             "GeoJSON",
@@ -690,6 +696,7 @@
                     "variables": {
                         "title": "Position query",
                         "description": "Position query",
+                        "query_type": "position",
                         "output_formats": [
                             "CoverageJSON",
                             "GeoJSON"
@@ -712,6 +719,7 @@
                     "variables": {
                         "title": "Radius query",
                         "description": "Radius query",
+                        "query_type": "radius",
                         "output_formats": [
                             "CoverageJSON",
                             "GeoJSON",
@@ -739,6 +747,7 @@
                     "variables": {
                         "title": "Area query",
                         "description": "Area query",
+                        "query_type": "area",
                         "output_formats": [
                             "CoverageJSON",
                             "GeoJSON",
@@ -1002,6 +1011,7 @@
                     "variables": {
                         "title": "Position query",
                         "description": "Position query",
+                        "query_type": "position",
                         "output_formats": [
                             "CoverageJSON",
                             "GeoJSON"
@@ -1024,6 +1034,7 @@
                     "variables": {
                         "title": "Radius query",
                         "description": "Radius query",
+                        "query_type": "radius",
                         "output_formats": [
                             "CoverageJSON",
                             "GeoJSON",
@@ -1051,6 +1062,7 @@
                     "variables": {
                         "title": "Area query",
                         "description": "Area query",
+                        "query_type": "area",
                         "output_formats": [
                             "CoverageJSON",
                             "GeoJSON",

--- a/candidate-standard/openapi/examples/instance.json
+++ b/candidate-standard/openapi/examples/instance.json
@@ -63,11 +63,11 @@
                     "hreflang": "en",
                     "rel": "data",
                     "title": "",
+                    "templated": true,
                     "variables": {
                         "title": "Position query",
                         "description": "Position query",
                         "query_type": "position",
-                        "templated": true,
                         "coords" :{
                             "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
                         },                        
@@ -89,11 +89,11 @@
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/radius?coords={coords}",
                     "hreflang": "en",
                     "rel": "data",
+                    "templated": true,
                     "variables": {
                         "title": "Radius query",
                         "description": "Radius query",
                         "query_type": "radius",
-                        "templated": true,
                         "coords" :{
                             "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
                         },                        
@@ -120,11 +120,11 @@
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/area?coords={coords}",
                     "hreflang": "en",
                     "rel": "data",
+                    "templated": true,
                     "variables": {
                         "title": "Area query",
                         "description": "Area query",
                         "query_type": "area",
-                        "templated": true,
                         "coords" :{
                             "description": "Well Known Text POLYGON value i.e. POLYGON((-79 40,-79 38,-75 38,-75 41,-79 40))"
                         },
@@ -147,11 +147,11 @@
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/locations",
                     "hreflang": "en",
                     "rel": "data",
+                    "templated": false,
                     "variables": {
                         "title": "Locations query",
                         "description": "Locations query",
                         "query_type": "location",
-                        "templated": false,
                         "output_formats": [
                             "CoverageJSON",
                             "GeoJSON"
@@ -403,11 +403,11 @@
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/position?coords={coords}",
                     "hreflang": "en",
                     "rel": "data",
+                    "templated": true,
                     "variables": {
                         "title": "Position query",
                         "description": "Position query",
                         "query_type": "position",
-                        "templated": true,
                         "coords" :{
                             "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
                         },                        
@@ -429,12 +429,11 @@
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/radius?coords={coords}",
                     "hreflang": "en",
                     "rel": "data",
-                    "title": "",
+                    "templated": true,
                     "variables": {
                         "title": "Radius query",
                         "description": "Radius query",
                         "query_type": "radius",
-                        "templated": true,
                         "coords" :{
                             "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
                         },
@@ -462,11 +461,11 @@
                     "hreflang": "en",
                     "rel": "data",
                     "title": "",
+                    "templated": true,
                     "variables": {
                         "title": "Area query",
                         "description": "Area query",
                         "query_type": "area",
-                        "templated": true,
                         "coords" :{
                             "description": "Well Known Text POLYGON value i.e. POLYGON((-79 40,-79 38,-75 38,-75 41,-79 40))"
                         },
@@ -489,11 +488,11 @@
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/locations",
                     "hreflang": "en",
                     "rel": "data",
+                    "templated": false,
                     "variables": {
                         "title": "Locations query",
                         "description": "Locations query",
                         "query_type": "location",
-                        "templated": false,
                         "output_formats": [
                             "CoverageJSON",
                             "GeoJSON"
@@ -745,11 +744,11 @@
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/position?coords={coords}",
                     "hreflang": "en",
                     "rel": "data",
+                    "templated": true,
                     "variables": {
                         "title": "Position query",
                         "description": "Position query",
                         "query_type": "position",
-                        "templated": true,
                         "coords" :{
                             "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
                         },
@@ -771,11 +770,11 @@
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/radius?coords={coords}",
                     "hreflang": "en",
                     "rel": "data",
+                    "templated": true,
                     "variables": {
                         "title": "Radius query",
                         "description": "Radius query",
                         "query_type": "radius",
-                        "templated": true,
                         "coords" :{
                             "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
                         },
@@ -802,11 +801,11 @@
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/area?coords={coords}",
                     "hreflang": "en",
                     "rel": "data",
+                    "templated": true,
                     "variables": {
                         "title": "Area query",
                         "description": "Area query",
                         "query_type": "area",
-                        "templated": true,
                         "coords" :{
                             "description": "Well Known Text POLYGON value i.e. POLYGON((-79 40,-79 38,-75 38,-75 41,-79 40))"
                         },
@@ -829,11 +828,11 @@
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/locations",
                     "hreflang": "en",
                     "rel": "data",
+                    "templated": false,
                     "variables": {
                         "title": "Locations query",
                         "description": "Locations query",
                         "query_type": "location",
-                        "templated": false,
                         "output_formats": [
                             "CoverageJSON",
                             "GeoJSON"
@@ -1085,11 +1084,11 @@
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/position?coords={coords}",
                     "hreflang": "en",
                     "rel": "data",
+                    "templated": true,
                     "variables": {
                         "title": "Position query",
                         "description": "Position query",
                         "query_type": "position",
-                        "templated": true,
                         "coords" :{
                             "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
                         },
@@ -1111,12 +1110,11 @@
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/radius?coords={coords}",
                     "hreflang": "en",
                     "rel": "data",
-                    "title": "",
+                    "templated": true,
                     "variables": {
                         "title": "Radius query",
                         "description": "Radius query",
                         "query_type": "radius",
-                        "templated": true,
                         "coords" :{
                             "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
                         },
@@ -1143,11 +1141,11 @@
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/area?coords={coords}",
                     "hreflang": "en",
                     "rel": "data",
+                    "templated": true,
                     "variables": {
                         "title": "Area query",
                         "description": "Area query",
                         "query_type": "area",
-                        "templated": true,
                         "coords" :{
                             "description": "Well Known Text POLYGON value i.e. POLYGON((-79 40,-79 38,-75 38,-75 41,-79 40))"
                         },
@@ -1170,11 +1168,11 @@
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/locations",
                     "hreflang": "en",
                     "rel": "data",
+                    "templated": false,
                     "variables": {
                         "title": "Locations query",
                         "description": "Locations query",
                         "query_type": "location",
-                        "templated": false,
                         "output_formats": [
                             "CoverageJSON",
                             "GeoJSON"

--- a/candidate-standard/openapi/examples/instance.json
+++ b/candidate-standard/openapi/examples/instance.json
@@ -103,7 +103,7 @@
                             "CSV"
                         ],
                         "default_output_format": "GeoJSON",
-                        "width_units": [
+                        "within_units": [
                             "km",
                             "miles"
                         ],
@@ -443,7 +443,7 @@
                             "CSV"
                         ],
                         "default_output_format": "GeoJSON",
-                        "width_units": [
+                        "within_units": [
                             "km",
                             "miles"
                         ],
@@ -784,7 +784,7 @@
                             "CSV"
                         ],
                         "default_output_format": "GeoJSON",
-                        "width_units": [
+                        "within_units": [
                             "km",
                             "miles"
                         ],
@@ -1124,7 +1124,7 @@
                             "CSV"
                         ],
                         "default_output_format": "GeoJSON",
-                        "width_units": [
+                        "within_units": [
                             "km",
                             "miles"
                         ],

--- a/candidate-standard/openapi/examples/instance.json
+++ b/candidate-standard/openapi/examples/instance.json
@@ -1,19 +1,3 @@
-.Collection instance metadata response document
-=================
-This is an example of the metadata returned by the instances query
-
-(link:https://www.iana.org/assignments/link-relations/link-relations.xhtml[link relation type]: "items").
-
-There is a link to the instance response itself (link:https://www.iana.org/assignments/link-relations/link-relations.xhtml[link relation type]: "self"). 
-
-Representations of this resource in other formats are referenced using link:https://www.iana.org/assignments/link-relations/link-relations.xhtml[link relation type] "alternate".
-
-The data queries that are supported by each instance are referenced using link:https://www.iana.org/assignments/link-relations/link-relations.xhtml[link relation type] "data".
-
-There are also links to the license information for the observation and forecast data (using:https://www.iana.org/assignments/link-relations/link-relations.xhtml[link relation type] "license") and also the terms and conditions of service (using:https://www.iana.org/assignments/link-relations/link-relations.xhtml[link relation type] "restrictions") .
-
-[source,json]
-----
 {
     "links": [
         {
@@ -1324,5 +1308,3 @@ There are also links to the license information for the observation and forecast
         }
     ]
 }
-----
-=================

--- a/candidate-standard/openapi/examples/instance.json
+++ b/candidate-standard/openapi/examples/instance.json
@@ -59,111 +59,24 @@
             ],
             "links": [
                 {
-                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/position?coords={coords}",
+                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/position",
                     "hreflang": "en",
-                    "rel": "data",
-                    "title": "",
-                    "templated": true,
-                    "variables": {
-                        "title": "Position query",
-                        "description": "Position query",
-                        "query_type": "position",
-                        "coords" :{
-                            "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
-                        },                        
-                        "output_formats": [
-                            "CoverageJSON",
-                            "GeoJSON"
-                        ],
-                        "default_output_format": "GeoJSON",
-                        "crs_details": [
-                            {
-                                "crs": "CRS84",
-                                "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
-                            }
-                        ]    
-                    }
-
+                    "rel": "data"
                 },
                 {
-                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/radius?coords={coords}",
+                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/radius",
                     "hreflang": "en",
-                    "rel": "data",
-                    "templated": true,
-                    "variables": {
-                        "title": "Radius query",
-                        "description": "Radius query",
-                        "query_type": "radius",
-                        "coords" :{
-                            "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
-                        },                        
-                        "output_formats": [
-                            "CoverageJSON",
-                            "GeoJSON",
-                            "CSV"
-                        ],
-                        "default_output_format": "GeoJSON",
-                        "within_units": [
-                            "km",
-                            "miles"
-                        ],
-                        "crs_details": [
-                            {
-                                "crs": "CRS84",
-                                "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
-                            }
-                        ]    
-                    }
-
+                    "rel": "data"
                 },
                 {
-                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/area?coords={coords}",
+                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/area",
                     "hreflang": "en",
-                    "rel": "data",
-                    "templated": true,
-                    "variables": {
-                        "title": "Area query",
-                        "description": "Area query",
-                        "query_type": "area",
-                        "coords" :{
-                            "description": "Well Known Text POLYGON value i.e. POLYGON((-79 40,-79 38,-75 38,-75 41,-79 40))"
-                        },
-                        "output_formats": [
-                            "CoverageJSON",
-                            "GeoJSON",
-                            "CSV"
-                        ],
-                        "default_output_format": "CoverageJSON",
-                        "crs_details": [
-                            {
-                                "crs": "CRS84",
-                                "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
-                            }
-                        ]    
-                    }
-                    
+                    "rel": "data"
                 },
                 {
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/locations",
                     "hreflang": "en",
-                    "rel": "data",
-                    "templated": false,
-                    "variables": {
-                        "title": "Locations query",
-                        "description": "Locations query",
-                        "query_type": "location",
-                        "output_formats": [
-                            "CoverageJSON",
-                            "GeoJSON"
-                        ],
-                        "default_output_format": "GeoJSON",
-                        "crs_details": [
-                            {
-                                "crs": "CRS84",
-                                "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
-                            }
-                        ]    
-                    }
+                    "rel": "data"
                 }
             ],
             "extent": {
@@ -183,7 +96,123 @@
                     "trs": "TIMECRS[\"DateTime\",TDATUM[\"Gregorian Calendar\"],CS[TemporalDateTime,1],AXIS[\"Time (T)\",future]"
                 }
             },
-            "crs": ["CRS84"],
+            "data_queries": {
+                "position": {
+                    "link": {
+                        "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/position?coords={coords}",
+                        "hreflang": "en",
+                        "rel": "data",
+                        "title": "",
+                        "templated": true,
+                        "variables": {
+                            "title": "Position query",
+                            "description": "Position query",
+                            "query_type": "position",
+                            "coords": {
+                                "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
+                            },
+                            "output_formats": [
+                                "CoverageJSON",
+                                "GeoJSON"
+                            ],
+                            "default_output_format": "GeoJSON",
+                            "crs_details": [
+                                {
+                                    "crs": "CRS84",
+                                    "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "radius": {
+                    "link": {
+                        "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/radius?coords={coords}",
+                        "hreflang": "en",
+                        "rel": "data",
+                        "templated": true,
+                        "variables": {
+                            "title": "Radius query",
+                            "description": "Radius query",
+                            "query_type": "radius",
+                            "coords": {
+                                "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
+                            },
+                            "output_formats": [
+                                "CoverageJSON",
+                                "GeoJSON",
+                                "CSV"
+                            ],
+                            "default_output_format": "GeoJSON",
+                            "within_units": [
+                                "km",
+                                "miles"
+                            ],
+                            "crs_details": [
+                                {
+                                    "crs": "CRS84",
+                                    "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "area": {
+                    "link": {
+                        "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/area?coords={coords}",
+                        "hreflang": "en",
+                        "rel": "data",
+                        "templated": true,
+                        "variables": {
+                            "title": "Area query",
+                            "description": "Area query",
+                            "query_type": "area",
+                            "coords": {
+                                "description": "Well Known Text POLYGON value i.e. POLYGON((-79 40,-79 38,-75 38,-75 41,-79 40))"
+                            },
+                            "output_formats": [
+                                "CoverageJSON",
+                                "GeoJSON",
+                                "CSV"
+                            ],
+                            "default_output_format": "CoverageJSON",
+                            "crs_details": [
+                                {
+                                    "crs": "CRS84",
+                                    "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "locations": {
+                    "link": {
+                        "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/locations",
+                        "hreflang": "en",
+                        "rel": "data",
+                        "templated": false,
+                        "variables": {
+                            "title": "Locations query",
+                            "description": "Locations query",
+                            "query_type": "location",
+                            "output_formats": [
+                                "CoverageJSON",
+                                "GeoJSON"
+                            ],
+                            "default_output_format": "GeoJSON",
+                            "crs_details": [
+                                {
+                                    "crs": "CRS84",
+                                    "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            "crs": [
+                "CRS84"
+            ],
             "output_formats": [
                 "GeoJSON",
                 "CoverageJSON",
@@ -202,7 +231,7 @@
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/grib2/codeflag/4.2/_0-2-0",
-                        "label":  "Wind Direction"
+                        "label": "Wind Direction"
                     },
                     "measurementType": {
                         "method": "mean",
@@ -213,7 +242,7 @@
                     "type": "Parameter",
                     "description": "Average wind speed",
                     "unit": {
-                        "label":  "mph",
+                        "label": "mph",
                         "symbol": {
                             "value": "mph",
                             "type": "http://http://www.example.org/edr/metadata/units/mph"
@@ -232,7 +261,7 @@
                     "type": "Parameter",
                     "description": "Wind gusts are a rapid increase in strength of the wind relative to the wind speed.",
                     "unit": {
-                        "label":  "mph",
+                        "label": "mph",
                         "symbol": {
                             "value": "mph",
                             "type": "http://http://www.example.org/edr/metadata/units/mph"
@@ -270,7 +299,7 @@
                     "type": "Parameter",
                     "description": "",
                     "unit": {
-                        "label":  "weather",
+                        "label": "weather",
                         "symbol": {
                             "value": "",
                             "type": "http://http://www.example.org/edr/metadata/lookup/mo_dp_weather"
@@ -289,7 +318,7 @@
                     "type": "Parameter",
                     "description": "",
                     "unit": {
-                        "label":  "percent",
+                        "label": "percent",
                         "symbol": {
                             "value": "%",
                             "type": "http://http://www.example.org/edr/metadata/units/percent"
@@ -297,7 +326,7 @@
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/grib2/codeflag/4.2/_0-1-1",
-                        "label":  "Relative Humidity"
+                        "label": "Relative Humidity"
                     },
                     "measurementType": {
                         "method": "instantaneous",
@@ -308,7 +337,7 @@
                     "type": "Parameter",
                     "description": "",
                     "unit": {
-                        "label":  "degC",
+                        "label": "degC",
                         "symbol": {
                             "value": "°C",
                             "type": "http://http://www.example.org/edr/metadata/units/degC"
@@ -316,7 +345,7 @@
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/common/quantity-kind/_airTemperature",
-                        "label":  "Feels like temperature"
+                        "label": "Feels like temperature"
                     },
                     "measurementType": {
                         "method": "instantaneous",
@@ -327,7 +356,7 @@
                     "type": "Parameter",
                     "description": "",
                     "unit": {
-                        "label":  "UV_index",
+                        "label": "UV_index",
                         "symbol": {
                             "value": "",
                             "type": "http://http://www.example.org/edr/metadata/lookup/mo_dp_uv"
@@ -335,7 +364,7 @@
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/grib2/codeflag/4.2/_0-4-51",
-                        "label":  "UV index"
+                        "label": "UV index"
                     },
                     "measurementType": {
                         "method": "instantaneous",
@@ -346,7 +375,7 @@
                     "type": "Parameter",
                     "description": "",
                     "unit": {
-                        "label":  "percent",
+                        "label": "percent",
                         "symbol": {
                             "value": "%",
                             "type": "http://http://www.example.org/edr/metadata/units/percent"
@@ -354,7 +383,7 @@
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/grib2/codeflag/4.2/_0-1-1",
-                        "label":  "Probabilty of precipitation"
+                        "label": "Probabilty of precipitation"
                     },
                     "measurementType": {
                         "method": "instantaneous",
@@ -365,7 +394,7 @@
                     "type": "Parameter",
                     "description": "",
                     "unit": {
-                        "label":  "quality",
+                        "label": "quality",
                         "symbol": {
                             "value": "",
                             "type": "http://http://www.example.org/edr/metadata/lookup/mo_dp_visibility"
@@ -373,7 +402,7 @@
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/common/quantity-kind/_horizontalVisibility",
-                        "label":  "Visibility"
+                        "label": "Visibility"
                     },
                     "measurementType": {
                         "method": "instantaneous",
@@ -400,111 +429,24 @@
             ],
             "links": [
                 {
-                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/position?coords={coords}",
+                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/position",
                     "hreflang": "en",
-                    "rel": "data",
-                    "templated": true,
-                    "variables": {
-                        "title": "Position query",
-                        "description": "Position query",
-                        "query_type": "position",
-                        "coords" :{
-                            "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
-                        },                        
-                        "output_formats": [
-                            "CoverageJSON",
-                            "GeoJSON"
-                        ],
-                        "default_output_format": "GeoJSON",
-                        "crs_details": [
-                            {
-                                "crs": "CRS84",
-                                "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
-                            }
-                        ]    
-                    }
-
+                    "rel": "data"
                 },
                 {
-                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/radius?coords={coords}",
+                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/radius",
                     "hreflang": "en",
-                    "rel": "data",
-                    "templated": true,
-                    "variables": {
-                        "title": "Radius query",
-                        "description": "Radius query",
-                        "query_type": "radius",
-                        "coords" :{
-                            "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
-                        },
-                        "output_formats": [
-                            "CoverageJSON",
-                            "GeoJSON",
-                            "CSV"
-                        ],
-                        "default_output_format": "GeoJSON",
-                        "within_units": [
-                            "km",
-                            "miles"
-                        ],
-                        "crs_details": [
-                            {
-                                "crs": "CRS84",
-                                "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
-                            }
-                        ]    
-                    }
-
+                    "rel": "data"
                 },
                 {
-                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/area?coords={coords}",
+                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/area",
                     "hreflang": "en",
-                    "rel": "data",
-                    "title": "",
-                    "templated": true,
-                    "variables": {
-                        "title": "Area query",
-                        "description": "Area query",
-                        "query_type": "area",
-                        "coords" :{
-                            "description": "Well Known Text POLYGON value i.e. POLYGON((-79 40,-79 38,-75 38,-75 41,-79 40))"
-                        },
-                        "output_formats": [
-                            "CoverageJSON",
-                            "GeoJSON",
-                            "CSV"
-                        ],
-                        "default_output_format": "CoverageJSON",
-                        "crs_details": [
-                            {
-                                "crs": "CRS84",
-                                "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
-                            }
-                        ]    
-                    }
-                    
+                    "rel": "data"
                 },
                 {
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/locations",
                     "hreflang": "en",
-                    "rel": "data",
-                    "templated": false,
-                    "variables": {
-                        "title": "Locations query",
-                        "description": "Locations query",
-                        "query_type": "location",
-                        "output_formats": [
-                            "CoverageJSON",
-                            "GeoJSON"
-                        ],
-                        "default_output_format": "GeoJSON",
-                        "crs_details": [
-                            {
-                                "crs": "CRS84",
-                                "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
-                            }
-                        ]    
-                    }
+                    "rel": "data"
                 }
             ],
             "extent": {
@@ -524,7 +466,123 @@
                     "trs": "TIMECRS[\"DateTime\",TDATUM[\"Gregorian Calendar\"],CS[TemporalDateTime,1],AXIS[\"Time (T)\",future]"
                 }
             },
-            "crs": ["CRS84"],
+            "data_queries": {
+                "position": {
+                    "link": {
+                        "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/position?coords={coords}",
+                        "hreflang": "en",
+                        "rel": "data",
+                        "templated": true,
+                        "variables": {
+                            "title": "Position query",
+                            "description": "Position query",
+                            "query_type": "position",
+                            "coords": {
+                                "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
+                            },
+                            "output_formats": [
+                                "CoverageJSON",
+                                "GeoJSON"
+                            ],
+                            "default_output_format": "GeoJSON",
+                            "crs_details": [
+                                {
+                                    "crs": "CRS84",
+                                    "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "radius": {
+                    "link": {
+                        "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/radius?coords={coords}",
+                        "hreflang": "en",
+                        "rel": "data",
+                        "templated": true,
+                        "variables": {
+                            "title": "Radius query",
+                            "description": "Radius query",
+                            "query_type": "radius",
+                            "coords": {
+                                "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
+                            },
+                            "output_formats": [
+                                "CoverageJSON",
+                                "GeoJSON",
+                                "CSV"
+                            ],
+                            "default_output_format": "GeoJSON",
+                            "within_units": [
+                                "km",
+                                "miles"
+                            ],
+                            "crs_details": [
+                                {
+                                    "crs": "CRS84",
+                                    "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "area": {
+                    "link": {
+                        "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/area?coords={coords}",
+                        "hreflang": "en",
+                        "rel": "data",
+                        "title": "",
+                        "templated": true,
+                        "variables": {
+                            "title": "Area query",
+                            "description": "Area query",
+                            "query_type": "area",
+                            "coords": {
+                                "description": "Well Known Text POLYGON value i.e. POLYGON((-79 40,-79 38,-75 38,-75 41,-79 40))"
+                            },
+                            "output_formats": [
+                                "CoverageJSON",
+                                "GeoJSON",
+                                "CSV"
+                            ],
+                            "default_output_format": "CoverageJSON",
+                            "crs_details": [
+                                {
+                                    "crs": "CRS84",
+                                    "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "locations": {
+                    "link": {
+                        "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/locations",
+                        "hreflang": "en",
+                        "rel": "data",
+                        "templated": false,
+                        "variables": {
+                            "title": "Locations query",
+                            "description": "Locations query",
+                            "query_type": "location",
+                            "output_formats": [
+                                "CoverageJSON",
+                                "GeoJSON"
+                            ],
+                            "default_output_format": "GeoJSON",
+                            "crs_details": [
+                                {
+                                    "crs": "CRS84",
+                                    "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            "crs": [
+                "CRS84"
+            ],
             "output_formats": [
                 "GeoJSON",
                 "CoverageJSON",
@@ -543,7 +601,7 @@
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/grib2/codeflag/4.2/_0-2-0",
-                        "label":  "Wind Direction"
+                        "label": "Wind Direction"
                     },
                     "measurementType": {
                         "method": "mean",
@@ -554,7 +612,7 @@
                     "type": "Parameter",
                     "description": "Average wind speed",
                     "unit": {
-                        "label":  "mph",
+                        "label": "mph",
                         "symbol": {
                             "value": "mph",
                             "type": "http://http://www.example.org/edr/metadata/units/mph"
@@ -573,7 +631,7 @@
                     "type": "Parameter",
                     "description": "Wind gusts are a rapid increase in strength of the wind relative to the wind speed.",
                     "unit": {
-                        "label":  "mph",
+                        "label": "mph",
                         "symbol": {
                             "value": "mph",
                             "type": "http://http://www.example.org/edr/metadata/units/mph"
@@ -611,7 +669,7 @@
                     "type": "Parameter",
                     "description": "",
                     "unit": {
-                        "label":  "weather",
+                        "label": "weather",
                         "symbol": {
                             "value": "",
                             "type": "http://http://www.example.org/edr/metadata/lookup/mo_dp_weather"
@@ -630,7 +688,7 @@
                     "type": "Parameter",
                     "description": "",
                     "unit": {
-                        "label":  "percent",
+                        "label": "percent",
                         "symbol": {
                             "value": "%",
                             "type": "http://http://www.example.org/edr/metadata/units/percent"
@@ -638,7 +696,7 @@
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/grib2/codeflag/4.2/_0-1-1",
-                        "label":  "Relative Humidity"
+                        "label": "Relative Humidity"
                     },
                     "measurementType": {
                         "method": "instantaneous",
@@ -649,7 +707,7 @@
                     "type": "Parameter",
                     "description": "",
                     "unit": {
-                        "label":  "degC",
+                        "label": "degC",
                         "symbol": {
                             "value": "°C",
                             "type": "http://http://www.example.org/edr/metadata/units/degC"
@@ -657,7 +715,7 @@
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/common/quantity-kind/_airTemperature",
-                        "label":  "Feels like temperature"
+                        "label": "Feels like temperature"
                     },
                     "measurementType": {
                         "method": "instantaneous",
@@ -668,7 +726,7 @@
                     "type": "Parameter",
                     "description": "",
                     "unit": {
-                        "label":  "UV_index",
+                        "label": "UV_index",
                         "symbol": {
                             "value": "",
                             "type": "http://http://www.example.org/edr/metadata/lookup/mo_dp_uv"
@@ -676,7 +734,7 @@
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/grib2/codeflag/4.2/_0-4-51",
-                        "label":  "UV index"
+                        "label": "UV index"
                     },
                     "measurementType": {
                         "method": "instantaneous",
@@ -687,7 +745,7 @@
                     "type": "Parameter",
                     "description": "",
                     "unit": {
-                        "label":  "percent",
+                        "label": "percent",
                         "symbol": {
                             "value": "%",
                             "type": "http://http://www.example.org/edr/metadata/units/percent"
@@ -695,7 +753,7 @@
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/grib2/codeflag/4.2/_0-1-1",
-                        "label":  "Probabilty of precipitation"
+                        "label": "Probabilty of precipitation"
                     },
                     "measurementType": {
                         "method": "instantaneous",
@@ -706,7 +764,7 @@
                     "type": "Parameter",
                     "description": "",
                     "unit": {
-                        "label":  "quality",
+                        "label": "quality",
                         "symbol": {
                             "value": "",
                             "type": "http://http://www.example.org/edr/metadata/lookup/mo_dp_visibility"
@@ -714,7 +772,7 @@
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/common/quantity-kind/_horizontalVisibility",
-                        "label":  "Visibility"
+                        "label": "Visibility"
                     },
                     "measurementType": {
                         "method": "instantaneous",
@@ -741,110 +799,24 @@
             ],
             "links": [
                 {
-                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/position?coords={coords}",
+                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/position",
                     "hreflang": "en",
-                    "rel": "data",
-                    "templated": true,
-                    "variables": {
-                        "title": "Position query",
-                        "description": "Position query",
-                        "query_type": "position",
-                        "coords" :{
-                            "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
-                        },
-                        "output_formats": [
-                            "CoverageJSON",
-                            "GeoJSON"
-                        ],
-                        "default_output_format": "GeoJSON",
-                        "crs_details": [
-                            {
-                                "crs": "CRS84",
-                                "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
-                            }
-                        ]    
-                    }
-
+                    "rel": "data"
                 },
                 {
-                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/radius?coords={coords}",
+                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/radius",
                     "hreflang": "en",
-                    "rel": "data",
-                    "templated": true,
-                    "variables": {
-                        "title": "Radius query",
-                        "description": "Radius query",
-                        "query_type": "radius",
-                        "coords" :{
-                            "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
-                        },
-                        "output_formats": [
-                            "CoverageJSON",
-                            "GeoJSON",
-                            "CSV"
-                        ],
-                        "default_output_format": "GeoJSON",
-                        "within_units": [
-                            "km",
-                            "miles"
-                        ],
-                        "crs_details": [
-                            {
-                                "crs": "CRS84",
-                                "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
-                            }
-                        ]    
-                    }
-
+                    "rel": "data"
                 },
                 {
-                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/area?coords={coords}",
+                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/area",
                     "hreflang": "en",
-                    "rel": "data",
-                    "templated": true,
-                    "variables": {
-                        "title": "Area query",
-                        "description": "Area query",
-                        "query_type": "area",
-                        "coords" :{
-                            "description": "Well Known Text POLYGON value i.e. POLYGON((-79 40,-79 38,-75 38,-75 41,-79 40))"
-                        },
-                        "output_formats": [
-                            "CoverageJSON",
-                            "GeoJSON",
-                            "CSV"
-                        ],
-                        "default_output_format": "CoverageJSON",
-                        "crs_details": [
-                            {
-                                "crs": "CRS84",
-                                "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
-                            }
-                        ]    
-                    }
-                    
+                    "rel": "data"
                 },
                 {
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/locations",
                     "hreflang": "en",
-                    "rel": "data",
-                    "templated": false,
-                    "variables": {
-                        "title": "Locations query",
-                        "description": "Locations query",
-                        "query_type": "location",
-                        "output_formats": [
-                            "CoverageJSON",
-                            "GeoJSON"
-                        ],
-                        "default_output_format": "GeoJSON",
-                        "crs_details": [
-                            {
-                                "crs": "CRS84",
-                                "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
-                            }
-                        ]    
-                    }
+                    "rel": "data"
                 }
             ],
             "extent": {
@@ -864,7 +836,123 @@
                     "trs": "TIMECRS[\"DateTime\",TDATUM[\"Gregorian Calendar\"],CS[TemporalDateTime,1],AXIS[\"Time (T)\",future]"
                 }
             },
-            "crs": ["CRS84"],
+            "data_queries": {
+                "position": {
+                    "link": {
+                        "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/position?coords={coords}",
+                        "hreflang": "en",
+                        "rel": "data",
+                        "templated": true,
+                        "variables": {
+                            "title": "Position query",
+                            "description": "Position query",
+                            "query_type": "position",
+                            "coords": {
+                                "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
+                            },
+                            "output_formats": [
+                                "CoverageJSON",
+                                "GeoJSON"
+                            ],
+                            "default_output_format": "GeoJSON",
+                            "crs_details": [
+                                {
+                                    "crs": "CRS84",
+                                    "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "radius": {
+                    "link": {
+                        "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/radius?coords={coords}",
+                        "hreflang": "en",
+                        "rel": "data",
+                        "templated": true,
+                        "variables": {
+                            "title": "Radius query",
+                            "description": "Radius query",
+                            "query_type": "radius",
+                            "coords": {
+                                "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
+                            },
+                            "output_formats": [
+                                "CoverageJSON",
+                                "GeoJSON",
+                                "CSV"
+                            ],
+                            "default_output_format": "GeoJSON",
+                            "within_units": [
+                                "km",
+                                "miles"
+                            ],
+                            "crs_details": [
+                                {
+                                    "crs": "CRS84",
+                                    "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "area": {
+                    "link": {
+                        "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/area?coords={coords}",
+                        "hreflang": "en",
+                        "rel": "data",
+                        "title": "",
+                        "templated": true,
+                        "variables": {
+                            "title": "Area query",
+                            "description": "Area query",
+                            "query_type": "area",
+                            "coords": {
+                                "description": "Well Known Text POLYGON value i.e. POLYGON((-79 40,-79 38,-75 38,-75 41,-79 40))"
+                            },
+                            "output_formats": [
+                                "CoverageJSON",
+                                "GeoJSON",
+                                "CSV"
+                            ],
+                            "default_output_format": "CoverageJSON",
+                            "crs_details": [
+                                {
+                                    "crs": "CRS84",
+                                    "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "locations": {
+                    "link": {
+                        "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/locations",
+                        "hreflang": "en",
+                        "rel": "data",
+                        "templated": false,
+                        "variables": {
+                            "title": "Locations query",
+                            "description": "Locations query",
+                            "query_type": "location",
+                            "output_formats": [
+                                "CoverageJSON",
+                                "GeoJSON"
+                            ],
+                            "default_output_format": "GeoJSON",
+                            "crs_details": [
+                                {
+                                    "crs": "CRS84",
+                                    "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            "crs": [
+                "CRS84"
+            ],
             "output_formats": [
                 "GeoJSON",
                 "CoverageJSON",
@@ -883,7 +971,7 @@
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/grib2/codeflag/4.2/_0-2-0",
-                        "label":  "Wind Direction"
+                        "label": "Wind Direction"
                     },
                     "measurementType": {
                         "method": "mean",
@@ -894,7 +982,7 @@
                     "type": "Parameter",
                     "description": "Average wind speed",
                     "unit": {
-                        "label":  "mph",
+                        "label": "mph",
                         "symbol": {
                             "value": "mph",
                             "type": "http://http://www.example.org/edr/metadata/units/mph"
@@ -913,7 +1001,7 @@
                     "type": "Parameter",
                     "description": "Wind gusts are a rapid increase in strength of the wind relative to the wind speed.",
                     "unit": {
-                        "label":  "mph",
+                        "label": "mph",
                         "symbol": {
                             "value": "mph",
                             "type": "http://http://www.example.org/edr/metadata/units/mph"
@@ -951,7 +1039,7 @@
                     "type": "Parameter",
                     "description": "",
                     "unit": {
-                        "label":  "weather",
+                        "label": "weather",
                         "symbol": {
                             "value": "",
                             "type": "http://http://www.example.org/edr/metadata/lookup/mo_dp_weather"
@@ -970,7 +1058,7 @@
                     "type": "Parameter",
                     "description": "",
                     "unit": {
-                        "label":  "percent",
+                        "label": "percent",
                         "symbol": {
                             "value": "%",
                             "type": "http://http://www.example.org/edr/metadata/units/percent"
@@ -978,7 +1066,7 @@
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/grib2/codeflag/4.2/_0-1-1",
-                        "label":  "Relative Humidity"
+                        "label": "Relative Humidity"
                     },
                     "measurementType": {
                         "method": "instantaneous",
@@ -989,7 +1077,7 @@
                     "type": "Parameter",
                     "description": "",
                     "unit": {
-                        "label":  "degC",
+                        "label": "degC",
                         "symbol": {
                             "value": "°C",
                             "type": "http://http://www.example.org/edr/metadata/units/degC"
@@ -997,7 +1085,7 @@
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/common/quantity-kind/_airTemperature",
-                        "label":  "Feels like temperature"
+                        "label": "Feels like temperature"
                     },
                     "measurementType": {
                         "method": "instantaneous",
@@ -1008,7 +1096,7 @@
                     "type": "Parameter",
                     "description": "",
                     "unit": {
-                        "label":  "UV_index",
+                        "label": "UV_index",
                         "symbol": {
                             "value": "",
                             "type": "http://http://www.example.org/edr/metadata/lookup/mo_dp_uv"
@@ -1016,7 +1104,7 @@
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/grib2/codeflag/4.2/_0-4-51",
-                        "label":  "UV index"
+                        "label": "UV index"
                     },
                     "measurementType": {
                         "method": "instantaneous",
@@ -1027,7 +1115,7 @@
                     "type": "Parameter",
                     "description": "",
                     "unit": {
-                        "label":  "percent",
+                        "label": "percent",
                         "symbol": {
                             "value": "%",
                             "type": "http://http://www.example.org/edr/metadata/units/percent"
@@ -1035,7 +1123,7 @@
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/grib2/codeflag/4.2/_0-1-1",
-                        "label":  "Probabilty of precipitation"
+                        "label": "Probabilty of precipitation"
                     },
                     "measurementType": {
                         "method": "instantaneous",
@@ -1046,7 +1134,7 @@
                     "type": "Parameter",
                     "description": "",
                     "unit": {
-                        "label":  "quality",
+                        "label": "quality",
                         "symbol": {
                             "value": "",
                             "type": "http://http://www.example.org/edr/metadata/lookup/mo_dp_visibility"
@@ -1054,7 +1142,7 @@
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/common/quantity-kind/_horizontalVisibility",
-                        "label":  "Visibility"
+                        "label": "Visibility"
                     },
                     "measurementType": {
                         "method": "instantaneous",
@@ -1081,110 +1169,24 @@
             ],
             "links": [
                 {
-                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/position?coords={coords}",
+                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/position",
                     "hreflang": "en",
-                    "rel": "data",
-                    "templated": true,
-                    "variables": {
-                        "title": "Position query",
-                        "description": "Position query",
-                        "query_type": "position",
-                        "coords" :{
-                            "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
-                        },
-                        "output_formats": [
-                            "CoverageJSON",
-                            "GeoJSON"
-                        ],
-                        "default_output_format": "GeoJSON",
-                        "crs_details": [
-                            {
-                                "crs": "CRS84",
-                                "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
-                            }
-                        ]    
-                    }
-
+                    "rel": "data"
                 },
                 {
-                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/radius?coords={coords}",
+                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/radius",
                     "hreflang": "en",
-                    "rel": "data",
-                    "templated": true,
-                    "variables": {
-                        "title": "Radius query",
-                        "description": "Radius query",
-                        "query_type": "radius",
-                        "coords" :{
-                            "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
-                        },
-                        "output_formats": [
-                            "CoverageJSON",
-                            "GeoJSON",
-                            "CSV"
-                        ],
-                        "default_output_format": "GeoJSON",
-                        "within_units": [
-                            "km",
-                            "miles"
-                        ],
-                        "crs_details": [
-                            {
-                                "crs": "CRS84",
-                                "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
-                            }
-                        ]    
-                    }
-
+                    "rel": "data"
                 },
                 {
-                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/area?coords={coords}",
+                    "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/area",
                     "hreflang": "en",
-                    "rel": "data",
-                    "templated": true,
-                    "variables": {
-                        "title": "Area query",
-                        "description": "Area query",
-                        "query_type": "area",
-                        "coords" :{
-                            "description": "Well Known Text POLYGON value i.e. POLYGON((-79 40,-79 38,-75 38,-75 41,-79 40))"
-                        },
-                        "output_formats": [
-                            "CoverageJSON",
-                            "GeoJSON",
-                            "CSV"
-                        ],
-                        "default_output_format": "CoverageJSON",
-                        "crs_details": [
-                            {
-                                "crs": "CRS84",
-                                "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
-                            }
-                        ]    
-                    }
-                    
+                    "rel": "data"
                 },
                 {
                     "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/locations",
                     "hreflang": "en",
-                    "rel": "data",
-                    "templated": false,
-                    "variables": {
-                        "title": "Locations query",
-                        "description": "Locations query",
-                        "query_type": "location",
-                        "output_formats": [
-                            "CoverageJSON",
-                            "GeoJSON"
-                        ],
-                        "default_output_format": "GeoJSON",
-                        "crs_details": [
-                            {
-                                "crs": "CRS84",
-                                "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
-                            }
-                        ]    
-                    }
+                    "rel": "data"
                 }
             ],
             "extent": {
@@ -1204,7 +1206,122 @@
                     "trs": "TIMECRS[\"DateTime\",TDATUM[\"Gregorian Calendar\"],CS[TemporalDateTime,1],AXIS[\"Time (T)\",future]"
                 }
             },
-            "crs": ["CRS84"],
+            "data_queries": {
+                "position": {
+                    "link": {
+                        "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/position?coords={coords}",
+                        "hreflang": "en",
+                        "rel": "data",
+                        "templated": true,
+                        "variables": {
+                            "title": "Position query",
+                            "description": "Position query",
+                            "query_type": "position",
+                            "coords": {
+                                "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
+                            },
+                            "output_formats": [
+                                "CoverageJSON",
+                                "GeoJSON"
+                            ],
+                            "default_output_format": "GeoJSON",
+                            "crs_details": [
+                                {
+                                    "crs": "CRS84",
+                                    "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "radius": {
+                    "link": {
+                        "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/radius?coords={coords}",
+                        "hreflang": "en",
+                        "rel": "data",
+                        "templated": true,
+                        "variables": {
+                            "title": "Radius query",
+                            "description": "Radius query",
+                            "query_type": "radius",
+                            "coords": {
+                                "description": "Well Known Text POINT value i.e. POINT(-120, 55)"
+                            },
+                            "output_formats": [
+                                "CoverageJSON",
+                                "GeoJSON",
+                                "CSV"
+                            ],
+                            "default_output_format": "GeoJSON",
+                            "within_units": [
+                                "km",
+                                "miles"
+                            ],
+                            "crs_details": [
+                                {
+                                    "crs": "CRS84",
+                                    "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "area": {
+                    "link": {
+                        "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/area?coords={coords}",
+                        "hreflang": "en",
+                        "rel": "data",
+                        "templated": true,
+                        "variables": {
+                            "title": "Area query",
+                            "description": "Area query",
+                            "query_type": "area",
+                            "coords": {
+                                "description": "Well Known Text POLYGON value i.e. POLYGON((-79 40,-79 38,-75 38,-75 41,-79 40))"
+                            },
+                            "output_formats": [
+                                "CoverageJSON",
+                                "GeoJSON",
+                                "CSV"
+                            ],
+                            "default_output_format": "CoverageJSON",
+                            "crs_details": [
+                                {
+                                    "crs": "CRS84",
+                                    "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "locations": {
+                    "link": {
+                        "href": "http://http://www.example.org/edr/collections/3_hrly_fcst/instances/2020-06-30T10:00:00Z/locations",
+                        "hreflang": "en",
+                        "rel": "data",
+                        "templated": false,
+                        "variables": {
+                            "title": "Locations query",
+                            "description": "Locations query",
+                            "query_type": "location",
+                            "output_formats": [
+                                "CoverageJSON",
+                                "GeoJSON"
+                            ],
+                            "default_output_format": "GeoJSON",
+                            "crs_details": [
+                                {
+                                    "crs": "CRS84",
+                                    "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            "crs": [
+                "CRS84"
+            ],
             "output_formats": [
                 "GeoJSON",
                 "CoverageJSON",
@@ -1223,7 +1340,7 @@
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/grib2/codeflag/4.2/_0-2-0",
-                        "label":  "Wind Direction"
+                        "label": "Wind Direction"
                     },
                     "measurementType": {
                         "method": "mean",
@@ -1234,7 +1351,7 @@
                     "type": "Parameter",
                     "description": "Average wind speed",
                     "unit": {
-                        "label":  "mph",
+                        "label": "mph",
                         "symbol": {
                             "value": "mph",
                             "type": "http://http://www.example.org/edr/metadata/units/mph"
@@ -1253,7 +1370,7 @@
                     "type": "Parameter",
                     "description": "Wind gusts are a rapid increase in strength of the wind relative to the wind speed.",
                     "unit": {
-                        "label":  "mph",
+                        "label": "mph",
                         "symbol": {
                             "value": "mph",
                             "type": "http://http://www.example.org/edr/metadata/units/mph"
@@ -1291,7 +1408,7 @@
                     "type": "Parameter",
                     "description": "",
                     "unit": {
-                        "label":  "weather",
+                        "label": "weather",
                         "symbol": {
                             "value": "",
                             "type": "http://http://www.example.org/edr/metadata/lookup/mo_dp_weather"
@@ -1310,7 +1427,7 @@
                     "type": "Parameter",
                     "description": "",
                     "unit": {
-                        "label":  "percent",
+                        "label": "percent",
                         "symbol": {
                             "value": "%",
                             "type": "http://http://www.example.org/edr/metadata/units/percent"
@@ -1318,7 +1435,7 @@
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/grib2/codeflag/4.2/_0-1-1",
-                        "label":  "Relative Humidity"
+                        "label": "Relative Humidity"
                     },
                     "measurementType": {
                         "method": "instantaneous",
@@ -1329,7 +1446,7 @@
                     "type": "Parameter",
                     "description": "",
                     "unit": {
-                        "label":  "degC",
+                        "label": "degC",
                         "symbol": {
                             "value": "°C",
                             "type": "http://http://www.example.org/edr/metadata/units/degC"
@@ -1337,7 +1454,7 @@
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/common/quantity-kind/_airTemperature",
-                        "label":  "Feels like temperature"
+                        "label": "Feels like temperature"
                     },
                     "measurementType": {
                         "method": "instantaneous",
@@ -1348,7 +1465,7 @@
                     "type": "Parameter",
                     "description": "",
                     "unit": {
-                        "label":  "UV_index",
+                        "label": "UV_index",
                         "symbol": {
                             "value": "",
                             "type": "http://http://www.example.org/edr/metadata/lookup/mo_dp_uv"
@@ -1356,7 +1473,7 @@
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/grib2/codeflag/4.2/_0-4-51",
-                        "label":  "UV index"
+                        "label": "UV index"
                     },
                     "measurementType": {
                         "method": "instantaneous",
@@ -1367,7 +1484,7 @@
                     "type": "Parameter",
                     "description": "",
                     "unit": {
-                        "label":  "percent",
+                        "label": "percent",
                         "symbol": {
                             "value": "%",
                             "type": "http://http://www.example.org/edr/metadata/units/percent"
@@ -1375,7 +1492,7 @@
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/grib2/codeflag/4.2/_0-1-1",
-                        "label":  "Probabilty of precipitation"
+                        "label": "Probabilty of precipitation"
                     },
                     "measurementType": {
                         "method": "instantaneous",
@@ -1386,7 +1503,7 @@
                     "type": "Parameter",
                     "description": "",
                     "unit": {
-                        "label":  "quality",
+                        "label": "quality",
                         "symbol": {
                             "value": "",
                             "type": "http://http://www.example.org/edr/metadata/lookup/mo_dp_visibility"
@@ -1394,7 +1511,7 @@
                     },
                     "observedProperty": {
                         "id": "http://codes.wmo.int/common/quantity-kind/_horizontalVisibility",
-                        "label":  "Visibility"
+                        "label": "Visibility"
                     },
                     "measurementType": {
                         "method": "instantaneous",
@@ -1402,7 +1519,6 @@
                     }
                 }
             }
-
         }
     ]
 }

--- a/candidate-standard/openapi/schemas/collection.yaml
+++ b/candidate-standard/openapi/schemas/collection.yaml
@@ -58,6 +58,31 @@ properties:
       type: string
   extent:
     $ref: extent.yaml
+  data_queries:
+    position:
+      link: 
+        $ref: link.yaml
+    radius:
+      link: 
+        $ref: link.yaml
+    area:
+      link: 
+        $ref: link.yaml
+    cube:
+      link: 
+        $ref: link.yaml
+    trajectory:
+      link: 
+        $ref: link.yaml
+    corridor:
+      link: 
+        $ref: link.yaml
+    location:
+      link: 
+        $ref: link.yaml
+    item:
+      link: 
+        $ref: link.yaml
   crs:
     description: list of the coordinate reference systems the collection results can support
     type: array

--- a/candidate-standard/openapi/schemas/collection.yaml
+++ b/candidate-standard/openapi/schemas/collection.yaml
@@ -64,16 +64,17 @@ properties:
       type: string
   data-queries:
     description: Detailed information relevant to individual query types
-    position:
-      $ref: dataQuery.yaml
-    radius:
-      $ref: dataQuery.yaml
-    area:
-      $ref: dataQuery.yaml
-    trajectory:
-      $ref: dataQuery.yaml
-    corridor:
-      $ref: dataQuery.yaml
+    properties:
+      position:
+        $ref: dataQuery.yaml
+      radius:
+        $ref: dataQuery.yaml
+      area:
+        $ref: dataQuery.yaml
+      trajectory:
+        $ref: dataQuery.yaml
+      corridor:
+        $ref: dataQuery.yaml
   output-formats:
     description: list of formats the results can be presented in
     type: array

--- a/candidate-standard/openapi/schemas/collection.yaml
+++ b/candidate-standard/openapi/schemas/collection.yaml
@@ -58,23 +58,22 @@ properties:
   extent:
     $ref: extent.yaml
   crs:
-    description: list of the coordinate reference systems the collection results can
-      be produced in
+    description: list of the coordinate reference systems the collection results can support
     type: array
     items:
-      $ref: crsObject.yaml
-  referencemetadata:
-    description: Property to contain any extra metadata information that is specific
-      to the collection
-    type: object
-  distanceunits:
-    description: list of distance units radius distance values can be specified in
-    type: array
-    items: 
       type: string
-    example:
-      - km
-      - miles
+  dataQueries:
+    description: Detailed information relevant to individual query types
+    Position:
+      $ref: dataQuery.yaml
+    Radius:
+      $ref: dataQuery.yaml
+    Area:
+      $ref: dataQuery.yaml
+    Trajectory:
+      $ref: dataQuery.yaml
+    Corridor:
+      $ref: dataQuery.yaml
   outputformat:
     description: list of formats the results can be presented in
     type: array

--- a/candidate-standard/openapi/schemas/collection.yaml
+++ b/candidate-standard/openapi/schemas/collection.yaml
@@ -84,7 +84,7 @@ properties:
       - GeoJSON
       - IWXXM
       - GRIB
-  parameters:
+  parameter-names:
     description: list of the data parameters available in the collection
     type: object
     additionalProperties:

--- a/candidate-standard/openapi/schemas/collection.yaml
+++ b/candidate-standard/openapi/schemas/collection.yaml
@@ -62,7 +62,7 @@ properties:
     type: array
     items:
       type: string
-  dataQueries:
+  data-queries:
     description: Detailed information relevant to individual query types
     position:
       $ref: dataQuery.yaml
@@ -74,7 +74,7 @@ properties:
       $ref: dataQuery.yaml
     corridor:
       $ref: dataQuery.yaml
-  outputformat:
+  output-formats:
     description: list of formats the results can be presented in
     type: array
     items: 

--- a/candidate-standard/openapi/schemas/collection.yaml
+++ b/candidate-standard/openapi/schemas/collection.yaml
@@ -2,6 +2,7 @@ type: object
 required:
   - links
   - id
+  - parameter-names
 properties:
   links:
     type: array

--- a/candidate-standard/openapi/schemas/collection.yaml
+++ b/candidate-standard/openapi/schemas/collection.yaml
@@ -63,20 +63,7 @@ properties:
     type: array
     items:
       type: string
-  data-queries:
-    description: Detailed information relevant to individual query types
-    properties:
-      position:
-        $ref: dataQuery.yaml
-      radius:
-        $ref: dataQuery.yaml
-      area:
-        $ref: dataQuery.yaml
-      trajectory:
-        $ref: dataQuery.yaml
-      corridor:
-        $ref: dataQuery.yaml
-  output-formats:
+  output_formats:
     description: list of formats the results can be presented in
     type: array
     items: 
@@ -86,7 +73,7 @@ properties:
       - GeoJSON
       - IWXXM
       - GRIB
-  parameter-names:
+  parameter_names:
     description: list of the data parameters available in the collection
     type: object
     additionalProperties:

--- a/candidate-standard/openapi/schemas/collection.yaml
+++ b/candidate-standard/openapi/schemas/collection.yaml
@@ -64,15 +64,15 @@ properties:
       type: string
   dataQueries:
     description: Detailed information relevant to individual query types
-    Position:
+    position:
       $ref: dataQuery.yaml
-    Radius:
+    radius:
       $ref: dataQuery.yaml
-    Area:
+    area:
       $ref: dataQuery.yaml
-    Trajectory:
+    trajectory:
       $ref: dataQuery.yaml
-    Corridor:
+    corridor:
       $ref: dataQuery.yaml
   outputformat:
     description: list of formats the results can be presented in

--- a/candidate-standard/openapi/schemas/crsObject.yaml
+++ b/candidate-standard/openapi/schemas/crsObject.yaml
@@ -1,9 +1,9 @@
 type: object
 required:
-  - name
+  - crs
   - wkt
 properties:
-  name:
+  crs:
     description: name of the coordinate reference system, used as the value in the crs query parameter to define the required output CRS
     type: string
     example: native

--- a/candidate-standard/openapi/schemas/dataQuery.yaml
+++ b/candidate-standard/openapi/schemas/dataQuery.yaml
@@ -10,6 +10,11 @@ properties:
     description: description of the query
     type: string
     example: Query to return data for a defined well known text point
+  query_type:
+    description: Type of EDR query
+    type: string
+    enum: [position, radius, area, cube, trajectory, corridor, items, locations, instances]
+    example: trajectory  
   width_units:
     description: list of width distance units distance values can be specified in
     type: array

--- a/candidate-standard/openapi/schemas/dataQuery.yaml
+++ b/candidate-standard/openapi/schemas/dataQuery.yaml
@@ -10,7 +10,7 @@ properties:
     description: description of the query
     type: string
     example: Query to return data for a defined well known text point
-  width-units:
+  width_units:
     description: list of width distance units distance values can be specified in
     type: array
     items: 
@@ -18,7 +18,7 @@ properties:
     example:
       - km
       - miles
-  height-units:
+  height_units:
     description: list of height distance units distance values can be specified in
     type: array
     items: 
@@ -26,7 +26,7 @@ properties:
     example:
       - m
       - hPa
-  output-formats:
+  output_formats:
     description: list of formats the results can be presented in
     type: array
     items: 
@@ -36,10 +36,10 @@ properties:
       - GeoJSON
       - IWXXM
       - GRIB
-  default-output-format:
+  default_output_format:
     description: default outputformat
     type: string
-  crs-details:
+  crs_details:
     description: List of key/value definitions for the CRS's supported by a query.  The key is the query parameter and the value is the Well Known Text description
     type: array
     items:

--- a/candidate-standard/openapi/schemas/dataQuery.yaml
+++ b/candidate-standard/openapi/schemas/dataQuery.yaml
@@ -26,7 +26,7 @@ properties:
     example:
       - m
       - hPa
-  outputformat:
+  output-formats:
     description: list of formats the results can be presented in
     type: array
     items: 
@@ -36,10 +36,10 @@ properties:
       - GeoJSON
       - IWXXM
       - GRIB
-  defaultOutputFormat:
+  default-output-format:
     description: default outputformat
     type: string
-  crs:
+  crs-details:
     description: List of key/value definitions for the CRS's supported by a query.  The key is the query parameter and the value is the Well Known Text description
     type: array
     items:

--- a/candidate-standard/openapi/schemas/dataQuery.yaml
+++ b/candidate-standard/openapi/schemas/dataQuery.yaml
@@ -14,7 +14,14 @@ properties:
     description: Type of EDR query
     type: string
     enum: [position, radius, area, cube, trajectory, corridor, items, locations, instances]
-    example: trajectory  
+    example: trajectory
+  coords:
+    description: Description of valid coords query parameter values
+    type: object
+    properties:
+      description:
+      type: string
+      example: Well Known Text POINT definition i.e. POINT(-120 55)  
   width_units:
     description: list of width distance units distance values can be specified in
     type: array

--- a/candidate-standard/openapi/schemas/dataQuery.yaml
+++ b/candidate-standard/openapi/schemas/dataQuery.yaml
@@ -22,6 +22,14 @@ properties:
       description:
       type: string
       example: Well Known Text POINT definition i.e. POINT(-120 55)  
+  within_units:
+    description: list of distance units radius values can be specified in
+    type: array
+    items: 
+      type: string
+    example:
+      - km
+      - miles
   width_units:
     description: list of width distance units distance values can be specified in
     type: array

--- a/candidate-standard/openapi/schemas/dataQuery.yaml
+++ b/candidate-standard/openapi/schemas/dataQuery.yaml
@@ -1,0 +1,46 @@
+description: Property to contain any extra metadata information that is specific
+  to an individual data queries
+type: object
+properties:
+  title:
+    description: title of the query
+    type: string
+    example: Position query
+  description:
+    description: description of the query
+    type: string
+    example: Query to return data for a defined well known text point
+  width-units:
+    description: list of width distance units distance values can be specified in
+    type: array
+    items: 
+      type: string
+    example:
+      - km
+      - miles
+  height-units:
+    description: list of height distance units distance values can be specified in
+    type: array
+    items: 
+      type: string
+    example:
+      - m
+      - hPa
+  outputformat:
+    description: list of formats the results can be presented in
+    type: array
+    items: 
+      type: string
+    example:
+      - CoverageJSON
+      - GeoJSON
+      - IWXXM
+      - GRIB
+  defaultOutputFormat:
+    description: default outputformat
+    type: string
+  crs:
+    description: List of key/value definitions for the CRS's supported by a query.  The key is the query parameter and the value is the Well Known Text description
+    type: array
+    items:
+      $ref: crsObject.yaml

--- a/candidate-standard/openapi/schemas/link.yaml
+++ b/candidate-standard/openapi/schemas/link.yaml
@@ -20,3 +20,5 @@ properties:
     example: Monitoring site name
   length:
     type: integer
+  variables:
+    $ref: dataQuery.yaml

--- a/candidate-standard/openapi/schemas/link.yaml
+++ b/candidate-standard/openapi/schemas/link.yaml
@@ -20,5 +20,8 @@ properties:
     example: Monitoring site name
   length:
     type: integer
+  templated:
+    description: defines if the link href value is a template with values requiring replacement 
+    type: boolean
   variables:
     $ref: dataQuery.yaml


### PR DESCRIPTION
Updated the collection schema to add a property object to support custom metadata for individual query types. The implementation is different than the original proposal in that it has named properties for the queries which require custom information rather than an array of objects, the aim of this approach is to simplify looking up metadata required for a specific query. Details based on the ideas described in issue #166.