### PR TITLE
Fix to remove AsciiDoc build warning messages

### DIFF
--- a/candidate-standard/EDR-candidate-specification.adoc
+++ b/candidate-standard/EDR-candidate-specification.adoc
@@ -21,7 +21,7 @@
 |Publication Date:  <yyyy-mm-dd>
 |External identifier of this OGC(R) document: http://www.opengis.net/doc/is/ogcapi-edr-1/1.0
 |Internal reference number of this OGC(R) document:    19-086r2
-|Version: 0.9
+|Version: 0.10
 |Category: OGC(R) Implementation Specification
 |Editors:  Mark Burgoyne, Dave Blodgett, Chuck Heazel, Chris Little 
 |===

--- a/candidate-standard/abstract_tests/ATS_class_core.adoc
+++ b/candidate-standard/abstract_tests/ATS_class_core.adoc
@@ -1,13 +1,10 @@
 [[ats_core]]
 [cols="1,4",width="90%"]
-
 |===
-
 2+|*Conformance Class*
 2+|http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/core
 |Target type |Web API
 |Requirements Class |<<rc-core-section,http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/core>>
-
 |===
 
 ==== General Tests

--- a/candidate-standard/abstract_tests/ATS_class_instances.adoc
+++ b/candidate-standard/abstract_tests/ATS_class_instances.adoc
@@ -12,7 +12,7 @@
 
 ===== CRS 84
 
-include::core/ATS_crs84.adoc[]
+include::collections/ATS_crs84.adoc[]
 
 ==== Instance {root}/collections/{collectionId}/instances/{instanceId}
 
@@ -20,22 +20,13 @@ include::collections/ATS_src-md-op.adoc[]
 
 include::collections/ATS_src-md-success.adoc[]
 
-==== Instance {root}/collections/{collectionId}/instances/{instanceId}/{queryType}
-
-
-include::core/ATS_items.adoc[]
-
 
 ==== Second Tier Tests
 These tests are invoked by other tests.
 
-===== Extent
-
-include::core/ATS_rc-md-extent.adoc[]
 
 ===== Queries
 
-include::collections/ATS_rc-collection-info.adoc[]
 
 include::collections/ATS_rc-md-collection-info-table.adoc[]
 

--- a/candidate-standard/abstract_tests/ATS_class_queries.adoc
+++ b/candidate-standard/abstract_tests/ATS_class_queries.adoc
@@ -25,7 +25,7 @@ include::queries/ATS_trajectory.adoc[]
 
 ==== Collections and Instances
 
-===== Feature Collections {root}/collections
+===== Collections {root}/collections
 
 include::collections/ATS_rc-md-op.adoc[]
 
@@ -34,17 +34,12 @@ include::collections/ATS_rc-md-success.adoc[]
 
 include::collections/ATS_rc-md-success-table.adoc[]
 
-===== Feature Collection {root}/collections/{collectionId}
+=====  Collection {root}/collections/{collectionId}
 
 include::collections/ATS_src-md-op.adoc[]
 
 include::collections/ATS_src-md-success.adoc[]
 
-===== Features {root}/collections/{collectionId}/items
-
-NOTE: This test is too Feature centric. Will need to be greatly reduced in scope.
-
-include::core/ATS_items.adoc[]
 
 ===== Instances {root}/collections/{collectionId}/instances
 [[ats_instances_rc-md-op]]
@@ -63,11 +58,14 @@ include::instances/ATS_src-md-success.adoc[]
 ==== Second Tier Tests
 These tests are invoked by other tests.
 
+===== Items
+
+include::collections/ATS_rc-collection-info.adoc[]
+
+include::collections/ATS_rc-md-collection-info-links.adoc[]
 
 ===== Locations
 
 include::queries/ATS_locations.adoc[]
 
-===== No Data
 
-include::queries/ATS_no-data.adoc[]

--- a/candidate-standard/abstract_tests/collections/ATS_src-md-op.adoc
+++ b/candidate-standard/abstract_tests/collections/ATS_src-md-op.adoc
@@ -5,6 +5,8 @@
 ^|Test Purpose |Validate that the Collection content can be retrieved from the expected location.
 ^|Requirement |<<req_collections_src-md-op,/req/collections/src-md-op>>
 ^|Test Method |For every Feature Collection described in the Collections content, issue an HTTP GET request to the URL `/collections/{collectionId}` where `{collectionId}` is the `id` property for the collection.
-. Validate that a Collection was returned with a status code 200
-. Validate the contents of the returned document using test <<ats_collections_src-md-success,/conf/collections/src-md-success>>.
+
+* Validate that a Collection was returned with a status code 200
+
+* Validate the contents of the returned document using test <<ats_collections_src-md-success,/conf/collections/src-md-success>>.
 |===

--- a/candidate-standard/abstract_tests/core/ATS_rc-md-extent.adoc
+++ b/candidate-standard/abstract_tests/core/ATS_rc-md-extent.adoc
@@ -4,9 +4,11 @@
 ^|*Abstract Test {counter:ats-id}* |*/conf/core/rc-extent* 
 ^|Test Purpose |Validate that the `extent` property if it is present
 ^|Requirement |<<req_core_rc-extent,/req/core/rc-extent>>
-^|Test Method |. Verify that the `extent` provides bounding boxes that include all spatial geometries
-. Verify that if the `extent` provides time intervals that include all temporal geometries in this collection. 
-. A temporal extent of `null` indicates an open time interval.
-. Verify that if the `extent` provides vertical intervals that include all vertical geometries in this collection. 
-. A vertical extent of `null` indicates an open vertical interval.
+^|Test Method |
+
+* Verify that the `extent` provides bounding boxes that include all spatial geometries
+* Verify that if the `extent` provides time intervals that they include all temporal geometries in this collection. 
+* A temporal extent of `null` indicates an open time interval.
+* Verify that if the `extent` provides vertical intervals that they include all vertical geometries in this collection. 
+* A vertical extent of `null` indicates an open vertical interval.
 |===

--- a/candidate-standard/annex_history.adoc
+++ b/candidate-standard/annex_history.adoc
@@ -14,5 +14,7 @@
 |2020-10-20 |Oct 2020 Master|Chris Little |Definitions |Added missing Cube definition
 |2021-01-14 |Issue 170|Tom Kralidis | all |normalize query parameters as kebab-case
 |2021-01-20 |master branch|Tom Kralidis | all |Editorial updates, requirement update for z parameter
+|2021-02-18 |Master branch|Mark Burgoyne | all |Add dedicated width and height query parameters to the corridor query
+|2021-03-03 |Master branch|Mark Burgoyne | all |Simplify Cube query
 |2021-03-03 |Master branch|Chris Little | all |replace references to Environmental with spatio-temporal
 |===

--- a/candidate-standard/annex_requirements.adoc
+++ b/candidate-standard/annex_requirements.adoc
@@ -13,6 +13,7 @@ For clarity, the complete <<requirements-class-definition,requirements test clas
 
 include::requirements/requirements_class_core.adoc[]
 
+
 include::requirements/core/REQ_core_conformance.adoc[]
 
 include::requirements/edr/REQ_rc-coords-definition.adoc[]
@@ -46,14 +47,6 @@ include::requirements/edr/REQ_rc-within-response.adoc[]
 include::requirements/edr/REQ_rc-within-units-definition.adoc[]
 
 include::requirements/edr/REQ_rc-within-units-response.adoc[]
-
-include::requirements/edr/REQ_rc-min-z-definition.adoc[]
-
-include::requirements/edr/REQ_rc-min-z-response.adoc[]
-
-include::requirements/edr/REQ_rc-max-z-definition.adoc[]
-
-include::requirements/edr/REQ_rc-max-z-response.adoc[]
 
 include::requirements/edr/REQ_rc-resolution-x-definition.adoc[]
 

--- a/candidate-standard/requirements/edr/REQ_rc-z-response.adoc
+++ b/candidate-standard/requirements/edr/REQ_rc-z-response.adoc
@@ -8,16 +8,20 @@
 ^|D |An Arithmetic sequence using Recurring height intervals can be specified by **R**`number of intervals`**/**`min height`**/**`height interval`
 ^|E |If the `z` parameter is not provided, the server SHOULD return data at all available vertical levels
 |===
+[source,java]
+----
+single-level  = level
+interval-closed  = min-level "/" max-level
+level-list  = level1 "," level2 "," level3 
+repeating-interval = "R"number of intervals "/" min-level "/" height to increment by 
 
-
-* single-level  = level
-* interval-closed  = min-level "/" max-level
-* level-list  = level1 "," level2 "," level3 
-* repeating-interval = "R"number of intervals "/" min-level "/" height to increment by 
-
+----
 
 [source,java]
 ----
+
+Single level at level 850
+z=850
 
 All data between levels 100 and 550
 z=100/550
@@ -27,5 +31,5 @@ z=10,80,200
 
 Data at 20 levels at 50 unit intervals starting a level 100 
 z=R20/100/50 
-----
 
+----


### PR DESCRIPTION
Fixes the mistakes in the AsciiDoc files which were generating warning messages.  Also fixes the errors identified in #265 and #264 