### PR TITLE
Fix coordinate order in OpenAPI comments

### DIFF
--- a/candidate-standard/clause_8_queries.adoc
+++ b/candidate-standard/clause_8_queries.adoc
@@ -59,7 +59,7 @@ The OGC API-Common standards do not define any information resource types. Howev
 |/collections/{collectionId}/cube | Cube | Return data for a spatial <<cube-definition,cube>>
 |/collections/{collectionId}/trajectory | Trajectory | Return data along a defined <<trajectory-definition,trajectory>>
 |/collections/{collectionId}/corridor | Corridor | Return data within a spatio-temporal <<corridor-definition,corridor>>
-|/collections/{collectionId}/items | Item |Items associated with the `{collectionId}` <<collection-definition,collection>>.
+|/collections/{collectionId}/items | Items |Items associated with the `{collectionId}` <<collection-definition,collection>>.
 |/collections/{collectionId}/locations | Locations |Location identifers associated with the `{collectionId}` <<collection-definition,collection>>.
 |/collections/{collectionId}/instances | Instances | List the available instances of the <<collection-definition,collection>>
 |===

--- a/candidate-standard/openapi/parameters/cubeCoords.yaml
+++ b/candidate-standard/openapi/parameters/cubeCoords.yaml
@@ -16,7 +16,7 @@ description: |-
     For instance a cube that roughly describes an area that contains 
     South West England in WGS84 would look like
 
-    coords=POLYGON((-6.0 50.0,-4.35 50.0,-4.35 52.0,,-6.0 52.0,-6.0 50.0))
+    coords=POLYGON((-6.0 50.0,-4.35 50.0,-4.35 52.0,-6.0 52.0,-6.0 50.0))
 
     `If the WKT does not define a Rectangle the service will generate 
     an 400 error message`

--- a/candidate-standard/openapi/parameters/trajectoryCoords.yaml
+++ b/candidate-standard/openapi/parameters/trajectoryCoords.yaml
@@ -7,32 +7,32 @@ description: |-
     The trajectory is defined using a Well Known Text string following 
 
     A 2D trajectory, on the surface of earth with no time or height dimensions: 
-        coords=LINESTRING(-2.98 51.14 ,-2.87 51.36 ,-3.15 51.03 ,-3.48 50.74 ,-3.36 50.9 )
+        coords=LINESTRING(-2.87 51.14 , -2.98 51.36,-3.15 51.03 ,-3.48 50.74 ,-3.36 50.9 )
 
     A 2D trajectory, on the surface of earth with all for the same time and no height dimension, time value defined in ISO8601 format by the `datetime` query parameter : 
-        coords=LINESTRING(-2.98 51.14 ,-2.87 51.36 ,-3.15 51.03 ,-3.48 50.74 ,-3.36 50.9 )&time=2018-02-12T23:00:00Z 
+        coords=LINESTRING(-2.87 51.14 , -2.98 51.36 ,-3.15 51.03 ,-3.48 50.74 ,-3.36 50.9 )&time=2018-02-12T23:00:00Z 
         
     A 2D trajectory, on the surface of earth with no time value but at a fixed height level, height defined in the collection height units by the `z` query parameter : 
-        coords=LINESTRING(-2.98 51.14 ,-2.87 51.36 ,-3.15 51.03 ,-3.48 50.74 ,-3.36 50.9 )&z=850 
+        coords=LINESTRING(-2.87 51.14 , -2.98 51.36 ,-3.15 51.03 ,-3.48 50.74 ,-3.36 50.9 )&z=850 
 
     A 2D trajectory, on the surface of earth with all for the same time and at a fixed height level, time value defined in ISO8601 format by the `datetime` query parameter and height defined in the collection height units by the `z` query parameter : 
-        coords=LINESTRING(-2.98 51.14 ,-2.87 51.36 ,-3.15 51.03 ,-3.48 50.74 ,-3.36 50.9 )&time=2018-02-12T23:00:00Z&z=850 
+        coords=LINESTRING(-2.87 51.14 , -2.98 51.36 ,-3.15 51.03 ,-3.48 50.74 ,-3.36 50.9 )&time=2018-02-12T23:00:00Z&z=850 
 
     A 3D trajectory, on the surface of the earth but over a time range with no height values:
-    coords=LINESTRINGM(-2.98 51.14  1560507000,-2.87 51.36  1560507600,-3.15 51.03  1560508200,-3.48 50.74  1560508500,-3.36 50.9  1560510240)
+    coords=LINESTRINGM(-2.87 51.14  1560507000,-2.98 51.36  1560507600,-3.15 51.03  1560508200,-3.48 50.74  1560508500,-3.36 50.9  1560510240)
 
     A 3D trajectory, on the surface of the earth but over a time range with a fixed height value, height defined in the collection height units by the `z` query parameter : 
-    coords=LINESTRINGM(-2.98 51.14  1560507000,-2.87 51.36  1560507600,-3.15 51.03  1560508200,-3.48 50.74  1560508500,-3.36 50.9  1560510240)&z=200
+    coords=LINESTRINGM(-2.87 51.14  1560507000,-2.98 51.36  1560507600,-3.15 51.03  1560508200,-3.48 50.74  1560508500,-3.36 50.9  1560510240)&z=200
 
 
     A 3D trajectory, through a 3D volume with height or depth, but no defined time:
-    coords=LINESTRINGZ(-2.98 51.14  0.1,-2.87 51.36  0.2,-3.15 51.03  0.3,-3.48 50.74  0.4,-3.36 50.9  0.5)
+    coords=LINESTRINGZ(-2.87 51.14  0.1,-2.98 51.36  0.2,-3.15 51.03  0.3,-3.48 50.74  0.4,-3.36 50.9  0.5)
 
     A 3D trajectory, through a 3D volume with height or depth, but a fixed time time value defined in ISO8601 format by the `datetime` query parameter:
-    coords=LINESTRINGZ(-2.98 51.14  0.1,-2.87 51.36  0.2,-3.15 51.03  0.3,-3.48 50.74  0.4,-3.36 50.9  0.5)&time=2018-02-12T23:00:00Z
+    coords=LINESTRINGZ(-2.87 51.14  0.1,-2.98 51.36  0.2,-3.15 51.03  0.3,-3.48 50.74  0.4,-3.36 50.9  0.5)&time=2018-02-12T23:00:00Z
 
     A 4D trajectory, through a 3D volume but over a time range:
-    coords=LINESTRINGZM(-2.98 51.14 0.1 1560507000,-2.87 51.36 0.2 1560507600,-3.15 51.03 0.3 1560508200, -3.48 50.74 0.4 1560508500, -3.36 50.9 0.5 1560510240)
+    coords=LINESTRINGZM(-2.87 51.14 0.1 1560507000,-2.98 51.36 0.2 1560507600,-3.15 51.03 0.3 1560508200, -3.48 50.74 0.4 1560508500, -3.36 50.9 0.5 1560510240)
     (using either the `time` or `z` parameters with a 4D trajectory wil generate an error response)
 
     where Z in `LINESTRINGZ` and `LINESTRINGZM` refers to the height value.  

--- a/candidate-standard/openapi/parameters/trajectoryCoords.yaml
+++ b/candidate-standard/openapi/parameters/trajectoryCoords.yaml
@@ -7,32 +7,32 @@ description: |-
     The trajectory is defined using a Well Known Text string following 
 
     A 2D trajectory, on the surface of earth with no time or height dimensions: 
-        coords=LINESTRING(51.14 -2.98, 51.36 -2.87, 51.03 -3.15, 50.74 -3.48, 50.9 -3.36)
+        coords=LINESTRING(-2.98 51.14 ,-2.87 51.36 ,-3.15 51.03 ,-3.48 50.74 ,-3.36 50.9 )
 
     A 2D trajectory, on the surface of earth with all for the same time and no height dimension, time value defined in ISO8601 format by the `datetime` query parameter : 
-        coords=LINESTRING(51.14 -2.98, 51.36 -2.87, 51.03 -3.15, 50.74 -3.48, 50.9 -3.36)&time=2018-02-12T23:00:00Z 
+        coords=LINESTRING(-2.98 51.14 ,-2.87 51.36 ,-3.15 51.03 ,-3.48 50.74 ,-3.36 50.9 )&time=2018-02-12T23:00:00Z 
         
     A 2D trajectory, on the surface of earth with no time value but at a fixed height level, height defined in the collection height units by the `z` query parameter : 
-        coords=LINESTRING(51.14 -2.98, 51.36 -2.87, 51.03 -3.15, 50.74 -3.48, 50.9 -3.36)&z=850 
+        coords=LINESTRING(-2.98 51.14 ,-2.87 51.36 ,-3.15 51.03 ,-3.48 50.74 ,-3.36 50.9 )&z=850 
 
     A 2D trajectory, on the surface of earth with all for the same time and at a fixed height level, time value defined in ISO8601 format by the `datetime` query parameter and height defined in the collection height units by the `z` query parameter : 
-        coords=LINESTRING(51.14 -2.98, 51.36 -2.87, 51.03 -3.15, 50.74 -3.48, 50.9 -3.36)&time=2018-02-12T23:00:00Z&z=850 
+        coords=LINESTRING(-2.98 51.14 ,-2.87 51.36 ,-3.15 51.03 ,-3.48 50.74 ,-3.36 50.9 )&time=2018-02-12T23:00:00Z&z=850 
 
     A 3D trajectory, on the surface of the earth but over a time range with no height values:
-    coords=LINESTRINGM(51.14 -2.98 1560507000, 51.36 -2.87 1560507600, 51.03 -3.15 1560508200, 50.74 -3.48 1560508500, 50.9 -3.36 1560510240)
+    coords=LINESTRINGM(-2.98 51.14  1560507000,-2.87 51.36  1560507600,-3.15 51.03  1560508200,-3.48 50.74  1560508500,-3.36 50.9  1560510240)
 
     A 3D trajectory, on the surface of the earth but over a time range with a fixed height value, height defined in the collection height units by the `z` query parameter : 
-    coords=LINESTRINGM(51.14 -2.98 1560507000, 51.36 -2.87 1560507600, 51.03 -3.15 1560508200, 50.74 -3.48 1560508500, 50.9 -3.36 1560510240)&z=200
+    coords=LINESTRINGM(-2.98 51.14  1560507000,-2.87 51.36  1560507600,-3.15 51.03  1560508200,-3.48 50.74  1560508500,-3.36 50.9  1560510240)&z=200
 
 
     A 3D trajectory, through a 3D volume with height or depth, but no defined time:
-    coords=LINESTRINGZ(51.14 -2.98 0.1, 51.36 -2.87 0.2, 51.03 -3.15 0.3, 50.74 -3.48 0.4, 50.9 -3.36 0.5)
+    coords=LINESTRINGZ(-2.98 51.14  0.1,-2.87 51.36  0.2,-3.15 51.03  0.3,-3.48 50.74  0.4,-3.36 50.9  0.5)
 
     A 3D trajectory, through a 3D volume with height or depth, but a fixed time time value defined in ISO8601 format by the `datetime` query parameter:
-    coords=LINESTRINGZ(51.14 -2.98 0.1, 51.36 -2.87 0.2, 51.03 -3.15 0.3, 50.74 -3.48 0.4, 50.9 -3.36 0.5)&time=2018-02-12T23:00:00Z
+    coords=LINESTRINGZ(-2.98 51.14  0.1,-2.87 51.36  0.2,-3.15 51.03  0.3,-3.48 50.74  0.4,-3.36 50.9  0.5)&time=2018-02-12T23:00:00Z
 
     A 4D trajectory, through a 3D volume but over a time range:
-    coords=LINESTRINGZM(51.14 -2.98 0.1 1560507000,51.36 -2.87 0.2 1560507600, 51.03 -3.15 0.3 1560508200, 50.74 -3.48 0.4 1560508500, 50.9 -3.36 0.5 1560510240)
+    coords=LINESTRINGZM(-2.98 51.14 0.1 1560507000,-2.87 51.36 0.2 1560507600,-3.15 51.03 0.3 1560508200, -3.48 50.74 0.4 1560508500, -3.36 50.9 0.5 1560510240)
     (using either the `time` or `z` parameters with a 4D trajectory wil generate an error response)
 
     where Z in `LINESTRINGZ` and `LINESTRINGZM` refers to the height value.  


### PR DESCRIPTION
Fix the OpenAPI example text for Trajectory coordinates