### PR TITLE
Fix OpenAPI schema generated examples  issue #347

### DIFF
--- a/standard/openapi/schemas/areaDataQuery.yaml
+++ b/standard/openapi/schemas/areaDataQuery.yaml
@@ -1,0 +1,53 @@
+description: Property to contain any extra metadata information that is specific
+  to an individual data queries
+type: object
+properties:
+  title:
+    description: title of the query
+    type: string
+    example: Area query
+  description:
+    description: description of the query
+    type: string
+    example: Query to return data for a defined area
+  query_type:
+    description: Type of EDR query
+    type: string
+    enum: [area]
+    example: area
+  coords:
+    description: Well Known Text Polygon which describes the bounds of the area
+    type: object
+    properties:
+      description:
+        type: string
+      type:
+        type: string
+    example:
+      POLYGON((-110.055 42.288,-111.109 35.596,-96.699 32.982,-97.050 42.158,-110.055 42.288))
+  height_units:
+    description: list of height distance units distance values can be specified in
+    type: array
+    items: 
+      type: string
+    example:
+      - m
+      - hPa
+  output_formats:
+    description: list of output formats supported by the Area query
+    type: array
+    items: 
+      type: string
+    example:
+      - CoverageJSON
+      - GeoJSON
+      - IWXXM
+      - GRIB
+  default_output_format:
+    description: default output format for the Area query
+    type: string
+  crs_details:
+    description: List of key/value definitions for the CRS's supported by the Area query.  The key is the query parameter and the value is the Well Known Text description
+    type: array
+    items:
+      $ref: crsObject.yaml

--- a/standard/openapi/schemas/areaLink.yaml
+++ b/standard/openapi/schemas/areaLink.yaml
@@ -5,7 +5,7 @@ required:
 properties:
   href:
     type: string
-    example: http://data.example.com/collections/monitoringsites/locations/1234
+    example: http://data.example.com/collections/monitoringsites/area
   rel:
     type: string
     example: alternate
@@ -23,3 +23,5 @@ properties:
   templated:
     description: defines if the link href value is a template with values requiring replacement 
     type: boolean
+  variables:
+    $ref: areaDataQuery.yaml

--- a/standard/openapi/schemas/collection.yaml
+++ b/standard/openapi/schemas/collection.yaml
@@ -67,42 +67,42 @@ properties:
         type: object
         properties:
           link:
-            $ref: link.yaml
+            $ref: positionLink.yaml
       radius:
         type: object
         properties:
           link:
-            $ref: link.yaml
+            $ref: radiusLink.yaml
       area:
         type: object
         properties:
           link:
-            $ref: link.yaml
+            $ref: areaLink.yaml
       cube:
         type: object
         properties:
           link:
-            $ref: link.yaml
+            $ref: cubeLink.yaml
       trajectory:
         type: object
         properties:
           link:
-            $ref: link.yaml
+            $ref: trajectoryLink.yaml
       corridor:
         type: object
         properties:
           link:
-            $ref: link.yaml
+            $ref: corridorLink.yaml
       locations:
         type: object
         properties:
           link:
-            $ref: link.yaml
+            $ref: locationsLink.yaml
       items:
         type: object
         properties:
           link:
-            $ref: link.yaml
+            $ref: itemsLink.yaml
   crs:
     description: list of the coordinate reference systems the collection results can support
     type: array

--- a/standard/openapi/schemas/corridorDataQuery.yaml
+++ b/standard/openapi/schemas/corridorDataQuery.yaml
@@ -1,0 +1,68 @@
+description: Property to contain any extra metadata information that is specific
+  to an individual data queries
+type: object
+properties:
+  title:
+    description: title of the query
+    type: string
+    example: Corridor query
+  description:
+    description: description of the query
+    type: string
+    example: Query to return data for a defined corridor
+  query_type:
+    description: Type of EDR query
+    type: string
+    enum: [corridor]
+    example: corridor
+  coords:
+    description: Definition of the center path of the corridor as Well Known Text 
+      LineString for A 2D corridor, on the surface of earth with no time or vertical dimensions (these can be specified for the whole corridor using datetime and z query parameters), 
+      LineStringM A 3D corridor, on the surface of the earth but over a range of time values with no height values (the z query parameter can specify a the height data for all points in the corridor)
+      LineStringZ A 3D corridor, through a 3D volume with vertical height or depth (the datetime query parameter can specify a the time data for all points in the corridor)
+      LineStringZM A 4D corridor, over a range of height and time values 
+    type: object
+    properties:
+      description:
+        type: string
+      type:
+        type: string
+    example:
+      - LINESTRING(-3.53 50.72, -3.35 50.92, -3.11 51.02, -2.85 51.42, -2.59 51.46)
+      - LINESTRINGM(-3.53 50.72 1560507000,-3.35 50.92 1560508800,-3.11 51.02 1560510600,-2.85 51.42 1560513600,-2.59 51.46 1560515400)
+      - LINESTRINGZ(-3.53 50.72 0.1,-3.35 50.92 0.2,-3.11 51.02 0.3,-2.85 51.42 0.4,-2.59 51.46 0.5)
+      - LINESTRINGZM(-3.53 50.72 0.1 1560507000,-3.35 50.92 0.2 1560508800,-3.11 51.02 0.3 1560510600,-2.85 51.42 0.4 1560513600,-2.59 51.46 0.5 1560515400)
+  width_units:
+    description: list of width distance units distance values can be specified in
+    type: array
+    items: 
+      type: string
+    example:
+      - km
+      - miles
+  height_units:
+    description: list of height distance units distance values can be specified in
+    type: array
+    items: 
+      type: string
+    example:
+      - m
+      - hPa
+  output_formats:
+    description: list of output formats the supported by the Corridor query
+    type: array
+    items: 
+      type: string
+    example:
+      - CoverageJSON
+      - GeoJSON
+      - IWXXM
+      - GRIB
+  default_output_format:
+    description: default output format for the Corridor query
+    type: string
+  crs_details:
+    description: List of key/value definitions for the CRS's supported by the Corridor query.  The key is the query parameter and the value is the Well Known Text description
+    type: array
+    items:
+      $ref: crsObject.yaml

--- a/standard/openapi/schemas/corridorLink.yaml
+++ b/standard/openapi/schemas/corridorLink.yaml
@@ -5,7 +5,7 @@ required:
 properties:
   href:
     type: string
-    example: http://data.example.com/collections/monitoringsites/locations/1234
+    example: http://data.example.com/collections/monitoringsites/corridor
   rel:
     type: string
     example: alternate
@@ -23,3 +23,5 @@ properties:
   templated:
     description: defines if the link href value is a template with values requiring replacement 
     type: boolean
+  variables:
+    $ref: corridorDataQuery.yaml

--- a/standard/openapi/schemas/cubeDataQuery.yaml
+++ b/standard/openapi/schemas/cubeDataQuery.yaml
@@ -1,0 +1,35 @@
+description: Property to contain any extra metadata information that is specific
+  to an individual data queries
+type: object
+properties:
+  title:
+    description: title of the query
+    type: string
+    example: Cube query
+  description:
+    description: description of the query
+    type: string
+    example: Query to return data for a defined well known text point
+  query_type:
+    description: Type of EDR query
+    type: string
+    enum: [cube]
+    example: cube
+  output_formats:
+    description: list of output formats supported by the Cube query
+    type: array
+    items: 
+      type: string
+    example:
+      - CoverageJSON
+      - GeoJSON
+      - IWXXM
+      - GRIB
+  default_output_format:
+    description: default output format of the Cube query
+    type: string
+  crs_details:
+    description: List of key/value definitions for the CRS's supported by the Cube query.  The key is the query parameter and the value is the Well Known Text description
+    type: array
+    items:
+      $ref: crsObject.yaml

--- a/standard/openapi/schemas/cubeLink.yaml
+++ b/standard/openapi/schemas/cubeLink.yaml
@@ -5,7 +5,7 @@ required:
 properties:
   href:
     type: string
-    example: http://data.example.com/collections/monitoringsites/locations/1234
+    example: http://data.example.com/collections/monitoringsites/cube
   rel:
     type: string
     example: alternate
@@ -23,3 +23,5 @@ properties:
   templated:
     description: defines if the link href value is a template with values requiring replacement 
     type: boolean
+  variables:
+    $ref: cubeDataQuery.yaml

--- a/standard/openapi/schemas/itemsDataQuery.yaml
+++ b/standard/openapi/schemas/itemsDataQuery.yaml
@@ -1,0 +1,17 @@
+description: Property to contain any extra metadata information that is specific
+  to an individual data queries
+type: object
+properties:
+  title:
+    description: title of the query
+    type: string
+    example: Items query
+  description:
+    description: description of the query
+    type: string
+    example: Query to return data for a defined well known text point
+  query_type:
+    description: Type of EDR query
+    type: string
+    enum: [items]
+    example: items

--- a/standard/openapi/schemas/itemsLink.yaml
+++ b/standard/openapi/schemas/itemsLink.yaml
@@ -5,7 +5,7 @@ required:
 properties:
   href:
     type: string
-    example: http://data.example.com/collections/monitoringsites/locations/1234
+    example: http://data.example.com/collections/monitoringsites/items
   rel:
     type: string
     example: alternate
@@ -23,3 +23,5 @@ properties:
   templated:
     description: defines if the link href value is a template with values requiring replacement 
     type: boolean
+  variables:
+    $ref: itemsDataQuery.yaml

--- a/standard/openapi/schemas/locationsDataQuery.yaml
+++ b/standard/openapi/schemas/locationsDataQuery.yaml
@@ -1,0 +1,35 @@
+description: Property to contain any extra metadata information that is specific
+  to an individual data queries
+type: object
+properties:
+  title:
+    description: title of the query
+    type: string
+    example: Locations query
+  description:
+    description: description of the query
+    type: string
+    example: Query to return data for a defined well known text point
+  query_type:
+    description: Type of EDR query
+    type: string
+    enum: [locations]
+    example: locations
+  output_formats:
+    description: list of output formats supported by the Locations query
+    type: array
+    items: 
+      type: string
+    example:
+      - CoverageJSON
+      - GeoJSON
+      - IWXXM
+      - GRIB
+  default_output_format:
+    description: default output format of the Locations query
+    type: string
+  crs_details:
+    description: List of key/value definitions for the CRS's supported by the Locations query.  The key is the query parameter and the value is the Well Known Text description
+    type: array
+    items:
+      $ref: crsObject.yaml

--- a/standard/openapi/schemas/locationsLink.yaml
+++ b/standard/openapi/schemas/locationsLink.yaml
@@ -5,7 +5,7 @@ required:
 properties:
   href:
     type: string
-    example: http://data.example.com/collections/monitoringsites/locations/1234
+    example: http://data.example.com/collections/monitoringsites/locations
   rel:
     type: string
     example: alternate
@@ -23,3 +23,5 @@ properties:
   templated:
     description: defines if the link href value is a template with values requiring replacement 
     type: boolean
+  variables:
+    $ref: locationsDataQuery.yaml

--- a/standard/openapi/schemas/observedPropertyCollection.yaml
+++ b/standard/openapi/schemas/observedPropertyCollection.yaml
@@ -1,6 +1,6 @@
 type: object
 title: name of property
-description: Description of the property which allows plain strings as well as i18n values
+description: Description of the property
 required:
   - label
 properties:
@@ -17,8 +17,8 @@ properties:
       - type: object
         required:
          - en
-        properties:
-          en:
+        patternProperties:
+          ".+":
             type: string
   description:
     type: string
@@ -44,8 +44,8 @@ properties:
             - type: object
               required:
               - en
-              properties:
-                en:
+              patternProperties:
+                ".+":
                   type: string
         description:
           oneOf:

--- a/standard/openapi/schemas/parameterNames.yaml
+++ b/standard/openapi/schemas/parameterNames.yaml
@@ -13,10 +13,8 @@ properties:
     oneOf:
       - type: string
       - type: object
-        required:
-        - en
-        properties:
-          en:
+        patternProperties:
+          ".+":
             type: string
   label:
     type: string
@@ -32,12 +30,15 @@ properties:
     $ref: observedPropertyCollection.yaml
   categoryEncoding:
     type: object
-    additionalProperties:
-      oneOf:
-        - type: integer
-        - type: array
-          items:
-            type: integer
+    patternProperties:
+      ".+" :
+        oneOf:
+          - type: integer
+          - type: array
+            items:
+              type: integer
+            minItems: 1
+            uniqueItems: true
   extent:
     $ref: extent.yaml
   id:

--- a/standard/openapi/schemas/positionDataQuery.yaml
+++ b/standard/openapi/schemas/positionDataQuery.yaml
@@ -1,0 +1,44 @@
+description: Property to contain any extra metadata information that is specific
+  to an individual data queries
+type: object
+properties:
+  title:
+    description: title of the query
+    type: string
+    example: Position query
+  description:
+    description: description of the query
+    type: string
+    example: Query to return data for a defined well known text point
+  query_type:
+    description: Type of EDR query
+    type: string
+    enum: [position]
+    example: position
+  coords:
+    description:  Well Known Text Point which describes the required position
+    type: object
+    properties:
+      description:
+        type: string
+      type:
+        type: string
+    example: POINT(0 51.48)
+  output_formats:
+    description: list of output formats supported by the Position query
+    type: array
+    items: 
+      type: string
+    example:
+      - CoverageJSON
+      - GeoJSON
+      - IWXXM
+      - GRIB
+  default_output_format:
+    description: default output format for the Position query
+    type: string
+  crs_details:
+    description: List of key/value definitions for the CRS's supported by the Position query.  The key is the query parameter and the value is the Well Known Text description
+    type: array
+    items:
+      $ref: crsObject.yaml

--- a/standard/openapi/schemas/positionLink.yaml
+++ b/standard/openapi/schemas/positionLink.yaml
@@ -5,7 +5,7 @@ required:
 properties:
   href:
     type: string
-    example: http://data.example.com/collections/monitoringsites/locations/1234
+    example: http://data.example.com/collections/monitoringsites/position
   rel:
     type: string
     example: alternate
@@ -23,3 +23,5 @@ properties:
   templated:
     description: defines if the link href value is a template with values requiring replacement 
     type: boolean
+  variables:
+    $ref: positionDataQuery.yaml

--- a/standard/openapi/schemas/radiusDataQuery.yaml
+++ b/standard/openapi/schemas/radiusDataQuery.yaml
@@ -5,7 +5,7 @@ properties:
   title:
     description: title of the query
     type: string
-    example: Position query
+    example: Radius query
   description:
     description: description of the query
     type: string
@@ -13,18 +13,17 @@ properties:
   query_type:
     description: Type of EDR query
     type: string
-    enum: [position, radius, area, cube, trajectory, corridor, items, locations, instances]
-    example: trajectory
+    enum: [radius]
+    example: radius
   coords:
-    description: Description of valid coords query parameter values
+    description: Well Known Text Point which describes the center position of the circular area to retrieve data for
     type: object
     properties:
       description:
         type: string
       type:
         type: string
-      example:
-        type: string
+    example:  POINT(149.127 -35.293)
   within_units:
     description: list of distance units radius values can be specified in
     type: array
@@ -33,24 +32,8 @@ properties:
     example:
       - km
       - miles
-  width_units:
-    description: list of width distance units distance values can be specified in
-    type: array
-    items: 
-      type: string
-    example:
-      - km
-      - miles
-  height_units:
-    description: list of height distance units distance values can be specified in
-    type: array
-    items: 
-      type: string
-    example:
-      - m
-      - hPa
   output_formats:
-    description: list of formats the results can be presented in
+    description: list of formats supported by the Radius query
     type: array
     items: 
       type: string
@@ -60,10 +43,10 @@ properties:
       - IWXXM
       - GRIB
   default_output_format:
-    description: default outputformat
+    description: default outputformat for the Radius query
     type: string
   crs_details:
-    description: List of key/value definitions for the CRS's supported by a query.  The key is the query parameter and the value is the Well Known Text description
+    description: List of key/value definitions for the CRS's supported by the Radius query.  The key is the query parameter and the value is the Well Known Text description
     type: array
     items:
       $ref: crsObject.yaml

--- a/standard/openapi/schemas/radiusLink.yaml
+++ b/standard/openapi/schemas/radiusLink.yaml
@@ -5,7 +5,7 @@ required:
 properties:
   href:
     type: string
-    example: http://data.example.com/collections/monitoringsites/locations/1234
+    example: http://data.example.com/collections/monitoringsites/radius
   rel:
     type: string
     example: alternate
@@ -23,3 +23,5 @@ properties:
   templated:
     description: defines if the link href value is a template with values requiring replacement 
     type: boolean
+  variables:
+    $ref: radiusDataQuery.yaml

--- a/standard/openapi/schemas/trajectoryDataQuery.yaml
+++ b/standard/openapi/schemas/trajectoryDataQuery.yaml
@@ -1,0 +1,52 @@
+description: Property to contain any extra metadata information that is specific
+  to an individual data queries
+type: object
+properties:
+  title:
+    description: title of the query
+    type: string
+    example: Trajectory query
+  description:
+    description: description of the query
+    type: string
+    example: Query to return data for a defined well known text point
+  query_type:
+    description: Type of EDR query
+    type: string
+    enum: [trajectory]
+    example: trajectory
+  coords:
+    description: Definition of the trajectory as Well Known Text 
+      LineString for A 2D trajectory, on the surface of earth with no time or vertical dimensions (these can be specified for the whole trajectory using datetime and z query parameters), 
+      LineStringM A 3D trajectory, on the surface of the earth but over a range of time values with no height values (the z query parameter can specify a the height data for all points in the trajectory)
+      LineStringZ A 3D trajectory, through a 3D volume with vertical height or depth (the datetime query parameter can specify a the time data for all points in the trajectory)
+      LineStringZM A 4D trajectory, over a range of height and time values 
+    type: object
+    properties:
+      description:
+        type: string
+      type:
+        type: string
+    example:
+      - LINESTRING(-3.53 50.72, -3.35 50.92, -3.11 51.02, -2.85 51.42, -2.59 51.46)
+      - LINESTRINGM(-3.53 50.72 1560507000,-3.35 50.92 1560508800,-3.11 51.02 1560510600,-2.85 51.42 1560513600,-2.59 51.46 1560515400)
+      - LINESTRINGZ(-3.53 50.72 0.1,-3.35 50.92 0.2,-3.11 51.02 0.3,-2.85 51.42 0.4,-2.59 51.46 0.5)
+      - LINESTRINGZM(-3.53 50.72 0.1 1560507000,-3.35 50.92 0.2 1560508800,-3.11 51.02 0.3 1560510600,-2.85 51.42 0.4 1560513600,-2.59 51.46 0.5 1560515400)
+  output_formats:
+    description: list of ouputformats supported by the Trajectory query
+    type: array
+    items: 
+      type: string
+    example:
+      - CoverageJSON
+      - GeoJSON
+      - IWXXM
+      - GRIB
+  default_output_format:
+    description: default outputformat for the Trajectory query
+    type: string
+  crs_details:
+    description: List of key/value definitions for the CRS's supported by a Trajectory query.  The key is the query parameter and the value is the Well Known Text description
+    type: array
+    items:
+      $ref: crsObject.yaml

--- a/standard/openapi/schemas/trajectoryLink.yaml
+++ b/standard/openapi/schemas/trajectoryLink.yaml
@@ -5,7 +5,7 @@ required:
 properties:
   href:
     type: string
-    example: http://data.example.com/collections/monitoringsites/locations/1234
+    example: http://data.example.com/collections/monitoringsites/trajectory
   rel:
     type: string
     example: alternate
@@ -23,3 +23,5 @@ properties:
   templated:
     description: defines if the link href value is a template with values requiring replacement 
     type: boolean
+  variables:
+    $ref: trajectoryDataQuery.yaml

--- a/standard/openapi/schemas/units.yaml
+++ b/standard/openapi/schemas/units.yaml
@@ -1,21 +1,24 @@
 type: object
 title: unit name
-description: definition of data units with allows plain strings as well as i18n values
-oneOf:
+description: definition of data units
+anyOf:   
   - required:
       - label
   - required:
+      - symbol
+  - required:
+      - label
       - symbol
 properties:
   label:
     oneOf:
       - type: object
-        properties:
-          en:
+        patternProperties:
+          ".+":
             type: string
       - type: string
   symbol:
-    title: Decribe unit symbol
+    title: Describe unit symbol
     oneOf:
       - type: object
         description: Information about the symbol used to describe the units


### PR DESCRIPTION
The problem was caused due to a generic dataQuery schema which contained all possible attribute values as optional values, the issue has been resolved by creating bespoke schemas for each of the data query patterns.