### PR TITLE
Remove coords property from Collections DataQuery metadata

### DIFF
--- a/standard/openapi/schemas/areaDataQuery.yaml
+++ b/standard/openapi/schemas/areaDataQuery.yaml
@@ -15,16 +15,6 @@ properties:
     type: string
     enum: [area]
     example: area
-  coords:
-    description: Well Known Text Polygon which describes the bounds of the area
-    type: object
-    properties:
-      description:
-        type: string
-      type:
-        type: string
-    example:
-      POLYGON((-110.055 42.288,-111.109 35.596,-96.699 32.982,-97.050 42.158,-110.055 42.288))
   height_units:
     description: list of height distance units distance values can be specified in
     type: array

--- a/standard/openapi/schemas/corridorDataQuery.yaml
+++ b/standard/openapi/schemas/corridorDataQuery.yaml
@@ -15,23 +15,6 @@ properties:
     type: string
     enum: [corridor]
     example: corridor
-  coords:
-    description: Definition of the center path of the corridor as Well Known Text 
-      LineString for A 2D corridor, on the surface of earth with no time or vertical dimensions (these can be specified for the whole corridor using datetime and z query parameters), 
-      LineStringM A 3D corridor, on the surface of the earth but over a range of time values with no height values (the z query parameter can specify a the height data for all points in the corridor)
-      LineStringZ A 3D corridor, through a 3D volume with vertical height or depth (the datetime query parameter can specify a the time data for all points in the corridor)
-      LineStringZM A 4D corridor, over a range of height and time values 
-    type: object
-    properties:
-      description:
-        type: string
-      type:
-        type: string
-    example:
-      - LINESTRING(-3.53 50.72, -3.35 50.92, -3.11 51.02, -2.85 51.42, -2.59 51.46)
-      - LINESTRINGM(-3.53 50.72 1560507000,-3.35 50.92 1560508800,-3.11 51.02 1560510600,-2.85 51.42 1560513600,-2.59 51.46 1560515400)
-      - LINESTRINGZ(-3.53 50.72 0.1,-3.35 50.92 0.2,-3.11 51.02 0.3,-2.85 51.42 0.4,-2.59 51.46 0.5)
-      - LINESTRINGZM(-3.53 50.72 0.1 1560507000,-3.35 50.92 0.2 1560508800,-3.11 51.02 0.3 1560510600,-2.85 51.42 0.4 1560513600,-2.59 51.46 0.5 1560515400)
   width_units:
     description: list of width distance units distance values can be specified in
     type: array

--- a/standard/openapi/schemas/positionDataQuery.yaml
+++ b/standard/openapi/schemas/positionDataQuery.yaml
@@ -15,15 +15,6 @@ properties:
     type: string
     enum: [position]
     example: position
-  coords:
-    description:  Well Known Text Point which describes the required position
-    type: object
-    properties:
-      description:
-        type: string
-      type:
-        type: string
-    example: POINT(0 51.48)
   output_formats:
     description: list of output formats supported by the Position query
     type: array

--- a/standard/openapi/schemas/radiusDataQuery.yaml
+++ b/standard/openapi/schemas/radiusDataQuery.yaml
@@ -15,15 +15,6 @@ properties:
     type: string
     enum: [radius]
     example: radius
-  coords:
-    description: Well Known Text Point which describes the center position of the circular area to retrieve data for
-    type: object
-    properties:
-      description:
-        type: string
-      type:
-        type: string
-    example:  POINT(149.127 -35.293)
   within_units:
     description: list of distance units radius values can be specified in
     type: array

--- a/standard/openapi/schemas/trajectoryDataQuery.yaml
+++ b/standard/openapi/schemas/trajectoryDataQuery.yaml
@@ -15,23 +15,6 @@ properties:
     type: string
     enum: [trajectory]
     example: trajectory
-  coords:
-    description: Definition of the trajectory as Well Known Text 
-      LineString for A 2D trajectory, on the surface of earth with no time or vertical dimensions (these can be specified for the whole trajectory using datetime and z query parameters), 
-      LineStringM A 3D trajectory, on the surface of the earth but over a range of time values with no height values (the z query parameter can specify a the height data for all points in the trajectory)
-      LineStringZ A 3D trajectory, through a 3D volume with vertical height or depth (the datetime query parameter can specify a the time data for all points in the trajectory)
-      LineStringZM A 4D trajectory, over a range of height and time values 
-    type: object
-    properties:
-      description:
-        type: string
-      type:
-        type: string
-    example:
-      - LINESTRING(-3.53 50.72, -3.35 50.92, -3.11 51.02, -2.85 51.42, -2.59 51.46)
-      - LINESTRINGM(-3.53 50.72 1560507000,-3.35 50.92 1560508800,-3.11 51.02 1560510600,-2.85 51.42 1560513600,-2.59 51.46 1560515400)
-      - LINESTRINGZ(-3.53 50.72 0.1,-3.35 50.92 0.2,-3.11 51.02 0.3,-2.85 51.42 0.4,-2.59 51.46 0.5)
-      - LINESTRINGZM(-3.53 50.72 0.1 1560507000,-3.35 50.92 0.2 1560508800,-3.11 51.02 0.3 1560510600,-2.85 51.42 0.4 1560513600,-2.59 51.46 0.5 1560515400)
   output_formats:
     description: list of ouputformats supported by the Trajectory query
     type: array


### PR DESCRIPTION
Remove the coords property from the DataQuery schemas, the property was originally intended as a way of providing an example of the coordinates query parameter in the collections metadata but this is duplicating the functionality provided by OpenAPI schemas and could prove confusing.