### PR TITLE
Add missing type values to schemas

### DIFF
--- a/standard/openapi/schemas/collections/parameterNames.yaml
+++ b/standard/openapi/schemas/collections/parameterNames.yaml
@@ -15,6 +15,7 @@ properties:
     type: string
   data-type:
     description: Data type of returned parameter
+    type: string
     enum:
       - integer
       - float

--- a/standard/openapi/schemas/covjson/coverageJSON.yaml
+++ b/standard/openapi/schemas/covjson/coverageJSON.yaml
@@ -25,6 +25,7 @@ properties:
       properties:
         type:
           description: Coverage domain type
+          type: string
           enum:
             - Coverage
         domain:

--- a/standard/openapi/schemas/covjson/domain.yaml
+++ b/standard/openapi/schemas/covjson/domain.yaml
@@ -3,6 +3,7 @@ description: A Domain, which defines a set of positions and their extent in one
 type: object
 properties:
   type:
+    type: string
     enum: 
       - Domain
   domainType:

--- a/standard/openapi/schemas/covjson/ndArray.yaml
+++ b/standard/openapi/schemas/covjson/ndArray.yaml
@@ -3,6 +3,7 @@ description: Object representing a multidimensional (>= 0D) array with named
   axes, encoded as a flat one-dimensional array in row-major order
 properties:
   type:
+    type: string
     enum: 
       - NdArray
   dataType:

--- a/standard/openapi/schemas/covjson/polygonValuesAxis.yaml
+++ b/standard/openapi/schemas/covjson/polygonValuesAxis.yaml
@@ -3,6 +3,7 @@ allOf:
   - $ref: valuesAxisBase.yaml
   - properties:
       dataType:
+        type: string
         enum: 
           - polygon
       values:

--- a/standard/openapi/schemas/covjson/tupleValuesAxis.yaml
+++ b/standard/openapi/schemas/covjson/tupleValuesAxis.yaml
@@ -3,6 +3,7 @@ allOf:
   - $ref: valuesAxisBase.yaml
   - properties:
       dataType:
+        type: string
         enum: 
           - tuple
       values:

--- a/standard/openapi/schemas/edr-geojson/parameter.yaml
+++ b/standard/openapi/schemas/edr-geojson/parameter.yaml
@@ -5,6 +5,7 @@ properties:
     type: string
   type:
     description: Type of the parameter object, must be "Parameter"
+    type: string
     enum: 
       - Parameter
   description:

--- a/standard/openapi/schemas/parameterGroup.yaml
+++ b/standard/openapi/schemas/parameterGroup.yaml
@@ -3,6 +3,7 @@ description: Represents logical groups of parameters
 properties:
   type:
     description: Type of the parameter group object, must be "ParameterGroup"
+    type: string
     enum: 
       - ParameterGroup
   id:

--- a/standard/requirements/edr/REQ_rc-coords-definition.adoc
+++ b/standard/requirements/edr/REQ_rc-coords-definition.adoc
@@ -6,7 +6,7 @@
 
 *A:*
 
-Each geometry based resource (Position, Radius, Area, Cube , Trajectory, Corridor) collection operation SHALL support a parameter `coords` with the following characteristics (using an OpenAPI Specification 3.0 fragment):
+Each geometry based resource (Position, Radius, Area, Trajectory, Corridor) collection operation SHALL support a parameter `coords` with the following characteristics (using an OpenAPI Specification 3.0 fragment):
 
 
 [source,YAML]


### PR DESCRIPTION
Fixes for other instances of the problem of missing type definitions identified in issue #420