### PR TITLE
Fix yaml schema indentation

### DIFF
--- a/core/standard/abstract_tests/core/ATS_rc-bbox-definition.adoc
+++ b/core/standard/abstract_tests/core/ATS_rc-bbox-definition.adoc
@@ -15,15 +15,15 @@ required: false
 schema:
   oneOf:
     - items:
-        minItems: 4
-        maxItems: 4
         type: number
-      type: array  
+      type: array
+      minItems: 4
+      maxItems: 4
     - items:
-        minItems: 6
-        maxItems: 6
         type: number
-      type: array  
+      type: array
+      minItems: 6
+      maxItems: 6
 style: form
 explode: false
 ----

--- a/core/standard/openapi/README.md
+++ b/core/standard/openapi/README.md
@@ -1,7 +1,7 @@
 # OpenAPI definitions
 
 This example API definition can be used to provide an OpenAPI 3.0 definition for an implementation of _OGC API - Environmental Data Retrieval_.
-The API definition can be visualized with [SwaggerUI](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/opengeospatial/ogcapi-environmental-data-retrieval/master/standard/openapi/ogcapi-environmental-data-retrieval-1.bundled.json).
+The API definition can be visualized with [SwaggerUI](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/opengeospatial/ogcapi-environmental-data-retrieval/master/core/standard/openapi/ogcapi-environmental-data-retrieval-1.bundled.json).
 
 The list of supported paths should be adjusted in `ogcapi-environmental-data-retrieval-1.yaml`.
 

--- a/core/standard/openapi/parameters/core/bbox.yaml
+++ b/core/standard/openapi/parameters/core/bbox.yaml
@@ -26,14 +26,14 @@ required: false
 schema:
   oneOf:
     - items:
-        minItems: 4
-        maxItems: 4
         type: number
-      type: array  
+      type: array
+      minItems: 4
+      maxItems: 4
     - items:
-        minItems: 6
-        maxItems: 6
         type: number
-      type: array  
+      type: array
+      minItems: 6
+      maxItems: 6
 style: form
 explode: false

--- a/core/standard/openapi/schemas/collections/extent.yaml
+++ b/core/standard/openapi/schemas/collections/extent.yaml
@@ -78,13 +78,13 @@ properties:
             - items:
                 type: number
               minItems: 4
-              maxItems: 4                
-              type: array  
+              maxItems: 4
+              type: array
             - items:
                 type: number
               minItems: 6
               maxItems: 6
-              type: array  
+              type: array
         example:
           - -180
           - -90

--- a/core/standard/requirements/core/REQ_rc-bbox-definition.adoc
+++ b/core/standard/requirements/core/REQ_rc-bbox-definition.adoc
@@ -20,15 +20,15 @@ required: false
 schema:
   oneOf:
     - items:
-        minItems: 4
-        maxItems: 4
         type: number
-      type: array  
+      type: array
+      minItems: 4
+      maxItems: 4
     - items:
-        minItems: 6
-        maxItems: 6
         type: number
-      type: array  
+      type: array
+      minItems: 6
+      maxItems: 6
 style: form
 explode: false
 ----

--- a/docs/edr_api.html
+++ b/docs/edr_api.html
@@ -7,7 +7,7 @@
         <script>
 
             function render() {
-                api_url = '../standard/openapi/ogcapi-environmental-data-retrieval-1.bundled.json';
+                api_url = '../core/standard/openapi/ogcapi-environmental-data-retrieval-1.bundled.json';
                 var ui = SwaggerUIBundle({
                     url:  api_url,
                     dom_id: '#swagger-ui',


### PR DESCRIPTION
Ref. https://github.com/opengeospatial/ogcapi-environmental-data-retrieval/issues/401

Seems errors mentioned in https://github.com/opengeospatial/ogcapi-environmental-data-retrieval/issues/401 are still present in published docs.