### PR TITLE
add OWSLib as a client implementation

### DIFF
--- a/implementations/clients/README.md
+++ b/implementations/clients/README.md
@@ -8,6 +8,8 @@ We welcome pull requests to update this page to add or update an entry for a cli
 
 ## Native APIs / Libraries
 
+- [OWSLib](owslib.md)
+
 ## JavaScript APIs
 
 - [covjson-reader](covjson-reader.md)

--- a/implementations/clients/owslib.md
+++ b/implementations/clients/owslib.md
@@ -1,0 +1,26 @@
+# OWSLib
+
+This page shows how to connect with [OWSLib](https://geopython.github.io/OWSLib) to an API that implements OGC API - Environmental Data Retrieval - Part 1: Core.
+
+## Links
+
+- [OWSLib OGC API - Environmental Data Retrieval documentation](http://geopython.github.io/OWSLib/#ogc-api-environmental-data-retrieval-1-0)
+
+## Software version
+
+This description uses the latest OWSLib release.
+
+## Required and supported Conformance classes
+
+The API must support the following conformance classes:
+
+- [Core](http://www.opengis.net/spec/ogcapi-edr-1/1.1/req/core)
+- [Queries](http://www.opengis.net/spec/ogcapi-edr-1/1.1/req/queries)
+- [JSON](http://www.opengis.net/spec/ogcapi-edr-1/1.1/req/json) conformance classes.
+- [GeoJSON](http://www.opengis.net/spec/ogcapi-edr-1/1.1/req/geojson) conformance classes.
+- [EDR GeoJSON](http://www.opengis.net/spec/ogcapi-edr-1/1.1/req/edr-geojson) conformance classes.
+- [OpenAPI 3.0](http://www.opengis.net/spec/ogcapi-edr-1/1.1/req/oas30) conformance classes.
+
+## Examples
+
+The examples in the OWSLib [documentation](https://owslib.readthedocs.io/en/latest/usage.html#ogc-api-environmental-data-retrieval-part-1-core-1-0) as well as [tests](https://github.com/geopython/OWSLib/blob/master/tests/test_ogcapi_edr_pygeoapi.py) exemplify functionality using position queries (note that any supported API server side query is possible).


### PR DESCRIPTION
Note: EDR supported [now in OWSLib](https://github.com/geopython/OWSLib/pull/899)

cc @ShaneMill1 