### PR TITLE
Update POST path for paths/queries/area.yaml to remove array character '-' from request body definition 

### DIFF
--- a/core/standard/openapi/paths/queries/area.yaml
+++ b/core/standard/openapi/paths/queries/area.yaml
@@ -39,7 +39,7 @@ post:
   parameters:
     $ref: ../../parameters/collections/collectionId.yaml  
   requestBody:
-    - $ref: ../../request-bodies/area.yaml  
+    $ref: ../../request-bodies/area.yaml  
   responses:
     200:
       $ref: ../../responses/queries/200.yaml

--- a/core/standard/openapi/paths/queries/area.yaml
+++ b/core/standard/openapi/paths/queries/area.yaml
@@ -37,7 +37,7 @@ post:
   description: Return the data values for the data area defined by the query parameters
   operationId: PostDataForArea
   parameters:
-    $ref: ../../parameters/collections/collectionId.yaml  
+    - $ref: ../../parameters/collections/collectionId.yaml  
   requestBody:
     $ref: ../../request-bodies/area.yaml  
   responses:


### PR DESCRIPTION
Removes array indicator '-' from request body reference. 

Marking it as an array also causes it to not be rendered in the swagger ui 

![image](https://github.com/opengeospatial/ogcapi-environmental-data-retrieval/assets/12314823/e7f24006-9244-49c5-946f-7366972fb1e7)
