### PR TITLE
link to schemas on schemas.opengis.net

### DIFF
--- a/extensions/pubsub/standard/openapi/schemas/link.yaml
+++ b/extensions/pubsub/standard/openapi/schemas/link.yaml
@@ -4,7 +4,7 @@ title: OGC API - Pub/Sub message payload link definition
 description: OGC API - Pub/Sub message payload link definition
 
 allOf:
-  - $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-common/v1.0-tc-vote/19-072/openapi/schemas/link.yaml'
+  - $ref: 'https://schemas.opengis.net/ogcapi/common/part1/1.0/openapi/schemas/link.yaml'
   - properties:
       channel:
         type: string

--- a/extensions/pubsub/standard/openapi/schemas/pubsub-message-payload-schema.yaml
+++ b/extensions/pubsub/standard/openapi/schemas/pubsub-message-payload-schema.yaml
@@ -11,11 +11,11 @@ required:
 
 properties:
   id:
-    $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/schemas/featureGeoJSON.yaml#/properties/id'
+    $ref: 'https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/schemas/featureGeoJSON.yaml#/properties/id'
   type:
-    $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/schemas/featureGeoJSON.yaml#/properties/type'
+    $ref: 'https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/schemas/featureGeoJSON.yaml#/properties/type'
   geometry:
-    $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/schemas/featureGeoJSON.yaml#/properties/geometry'
+    $ref: 'https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/schemas/featureGeoJSON.yaml#/properties/geometry'
   properties:
     type: object
     required:
@@ -42,4 +42,6 @@ properties:
           - delete
         default: create
   links:
-    $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/schemas/link.yaml'
+    type: array
+    items:
+      $ref: 'https://schemas.opengis.net/ogcapi/common/part1/1.0/openapi/schemas/link.yaml'


### PR DESCRIPTION
Uses definitions from schemas.opengis.net for stability.  As well, message payload JSON schema should define `links` as an array (also fixed in this PR).