### PR TITLE
Resolution schema fixes

### DIFF
--- a/core/standard/openapi/oas30/parameters/core/resolution-x.yaml
+++ b/core/standard/openapi/oas30/parameters/core/resolution-x.yaml
@@ -1,15 +1,14 @@
 name: resolution-x
 in: query
 description: |+
-  Defined it the user requires data at a different resolution from the native resolution of the data along the x-axis
+  Defined if the user requires data at a different resolution from the native resolution of the data along the x-axis
 
-  If this is a single value it denotes the number of intervals to retrieve data for along the x-axis
+  This is a single value it denotes the number of intervals to retrieve data for along the x-axis
     
     i.e. resolution-x=10 
     
   would retrieve 10 values along the x-axis from the minimum x coordinate to maximum x coordinate (i.e. a value at both the minimum x and maximum x coordinates and 8 values between).
 required: false
 schema:
-    items:
-      type: string
+    type: string
 

--- a/core/standard/openapi/oas30/parameters/core/resolution-y.yaml
+++ b/core/standard/openapi/oas30/parameters/core/resolution-y.yaml
@@ -1,14 +1,13 @@
 name: resolution-y
 in: query
 description: |+
-  Defined it the user requires data at a different resolution from the native resolution of the data along the y-axis
+  Defined if the user requires data at a different resolution from the native resolution of the data along the y-axis
 
-  If this is a single value it denotes the number of intervals to retrieve data for along the y-axis
+  This is a single value it denotes the number of intervals to retrieve data for along the y-axis
     
     i.e. resolution-y=10 
     
   would retrieve 10 values along the y-axis from the minimum y coordinate to maximum y coordinate (i.e. a value at both the minimum y and maximum y coordinates and 8 values between).
 required: false
 schema:
-    items:
-      type: string
+    type: string

--- a/core/standard/openapi/oas30/parameters/core/resolution-z.yaml
+++ b/core/standard/openapi/oas30/parameters/core/resolution-z.yaml
@@ -3,7 +3,7 @@ in: query
 description: |+
   Defined if the user requires data at a different resolution from the native resolution of the data along the z-axis
 
-  Tis is a single value it denotes the number of intervals to retrieve data for along the z-axis
+  This is a single value it denotes the number of intervals to retrieve data for along the z-axis
     
     i.e. resolution-z=10 
     

--- a/core/standard/openapi/oas30/parameters/core/resolution-z.yaml
+++ b/core/standard/openapi/oas30/parameters/core/resolution-z.yaml
@@ -1,14 +1,13 @@
 name: resolution-z
 in: query
 description: |+
-  Defined it the user requires data at a different resolution from the native resolution of the data along the z-axis
+  Defined if the user requires data at a different resolution from the native resolution of the data along the z-axis
 
-  If this is a single value it denotes the number of intervals to retrieve data for along the z-axis
+  Tis is a single value it denotes the number of intervals to retrieve data for along the z-axis
     
     i.e. resolution-z=10 
     
   would retrieve 10 values along the z-axis from the minimum z coordinate to maximum z  coordinate (i.e. a value at both the minimum z and maximum z coordinates and 8 values between).
 required: false
 schema:
-    items:
-      type: string
+    type: string

--- a/core/standard/openapi/oas31/parameters/core/resolution-x.yaml
+++ b/core/standard/openapi/oas31/parameters/core/resolution-x.yaml
@@ -3,7 +3,7 @@ in: query
 description: |+
   Defined if the user requires data at a different resolution from the native resolution of the data along the x-axis
 
- This is a single value it denotes the number of intervals to retrieve data for along the x-axis
+  This is a single value it denotes the number of intervals to retrieve data for along the x-axis
     
     i.e. resolution-x=10 
     

--- a/core/standard/openapi/oas31/parameters/core/resolution-x.yaml
+++ b/core/standard/openapi/oas31/parameters/core/resolution-x.yaml
@@ -1,15 +1,14 @@
 name: resolution-x
 in: query
 description: |+
-  Defined it the user requires data at a different resolution from the native resolution of the data along the x-axis
+  Defined if the user requires data at a different resolution from the native resolution of the data along the x-axis
 
-  If this is a single value it denotes the number of intervals to retrieve data for along the x-axis
+ This is a single value it denotes the number of intervals to retrieve data for along the x-axis
     
     i.e. resolution-x=10 
     
   would retrieve 10 values along the x-axis from the minimum x coordinate to maximum x coordinate (i.e. a value at both the minimum x and maximum x coordinates and 8 values between).
 required: false
 schema:
-    items:
-      type: string
+    type: string
 

--- a/core/standard/openapi/oas31/parameters/core/resolution-y.yaml
+++ b/core/standard/openapi/oas31/parameters/core/resolution-y.yaml
@@ -1,14 +1,13 @@
 name: resolution-y
 in: query
 description: |+
-  Defined it the user requires data at a different resolution from the native resolution of the data along the y-axis
+  Defined if the user requires data at a different resolution from the native resolution of the data along the y-axis
 
-  If this is a single value it denotes the number of intervals to retrieve data for along the y-axis
+  This is a single value it denotes the number of intervals to retrieve data for along the y-axis
     
     i.e. resolution-y=10 
     
   would retrieve 10 values along the y-axis from the minimum y coordinate to maximum y coordinate (i.e. a value at both the minimum y and maximum y coordinates and 8 values between).
 required: false
 schema:
-    items:
-      type: string
+    type: string

--- a/core/standard/openapi/oas31/parameters/core/resolution-z.yaml
+++ b/core/standard/openapi/oas31/parameters/core/resolution-z.yaml
@@ -1,14 +1,13 @@
 name: resolution-z
 in: query
 description: |+
-  Defined it the user requires data at a different resolution from the native resolution of the data along the z-axis
+  Defined if the user requires data at a different resolution from the native resolution of the data along the z-axis
 
-  If this is a single value it denotes the number of intervals to retrieve data for along the z-axis
+  This is a single value it denotes the number of intervals to retrieve data for along the z-axis
     
     i.e. resolution-z=10 
     
   would retrieve 10 values along the z-axis from the minimum z coordinate to maximum z  coordinate (i.e. a value at both the minimum z and maximum z coordinates and 8 values between).
 required: false
 schema:
-    items:
-      type: string
+    type: string


### PR DESCRIPTION
Fixes the resolution parameter schemas to match the normative OGC EDR specification and avoid incorrect client generation.

- align query parameter modeling with the OGC spec text rather than the inconsistent published schema artifacts
- clarify that each resolution parameter is a single scalar value, not an array/list
- replace incomplete items-only schemas with scalar parameter definitions