### PR TITLE
Add edr4r R client to implementations

### DIFF
--- a/implementations/README.adoc
+++ b/implementations/README.adoc
@@ -69,10 +69,10 @@ The columns for each part list the conformance classes of the standard that the 
 |===
 | Product | Conformance Classes | OGC Product Database | Contact email
 
-| TBD
-| TBD
-| TBD
-| TBD
+| https://github.com/ksonda/edr4r[edr4r] (R)
+| `core`, `queries`, `edr-geojson`, `covjson`
+| https://github.com/ksonda/edr4r[GitHub repo]
+| konda [at] lincolninst.edu
 
 |===
 

--- a/implementations/clients/README.md
+++ b/implementations/clients/README.md
@@ -8,7 +8,8 @@ We welcome pull requests to update this page to add or update an entry for a cli
 
 ## Native APIs / Libraries
 
-- [OWSLib](owslib.md)
+- [OWSLib](owslib.md) (Python)
+- [edr4r](https://github.com/ksonda/edr4r) (R)
 
 ## JavaScript APIs
 


### PR DESCRIPTION
Registers [edr4r](https://github.com/ksonda/edr4r) — a tidy R client for OGC API - EDR, published on CRAN (Comprehensive R Archive Network) — as a client implementation.

## Changes
- `implementations/clients/README.md` — listed edr4r under **Native APIs / Libraries**, linking the GitHub repo.
- `implementations/README.adoc` — filled the previously-`TBD` **Native APIs / Libraries** table row with edr4r, using the GitHub repo link in the product-database column (mirroring the QGIS plugin row).

## About edr4r
edr4r is a tidy R client that handles discovery, request construction, and parsing of EDR responses: CoverageJSON becomes long-format tibbles, EDR GeoJSON becomes `sf` objects, and CSV is parsed to tibbles. It supports the `locations`, `items`, `position`, `area`, `cube`, `radius`, `trajectory`, and `corridor` query types, and is regularly exercised against the USGS Water Data OGC API and the Western Water Datahub.

(A `tibble` is an R orientated tabular data structure.)

Contact: konda [at] lincolninst.edu